### PR TITLE
修复 qoder-cn 在 auth.json 缺失时 fallback 到假 userID 导致 500 错误

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,9 +71,12 @@ export default function (pi: ExtensionAPI) {
         const accessToken = await ctx.modelRegistry.getApiKeyForProvider(providerID);
         if (!accessToken || !isCacheStale(mode)) continue;
         const creds = getCachedCredentials(accessToken, providerID);
-        const userID = creds?.userID || "qoder-user";
-        const name = creds?.name || (isQoderCNMode(mode) ? "Qoder CN User" : "Qoder User");
-        const email = creds?.email || getQoderUserEmailFallback(mode);
+        // Skip model cache refresh if we cannot resolve a real userID.
+        // Calling the Qoder gateway with a placeholder userID causes HTTP 500.
+        if (!creds?.userID) continue;
+        const userID = creds.userID;
+        const name = creds.name || (isQoderCNMode(mode) ? "Qoder CN User" : "Qoder User");
+        const email = creds.email || getQoderUserEmailFallback(mode);
         await updateQoderModelsCache(accessToken, userID, name, email, mode);
       } catch {
         // Best-effort: fall back to the existing cache / static models.

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -113,12 +113,23 @@ export function streamQoder(
         );
       }
 
-      // Resolve user details from cached credentials
+      // Resolve user details from cached credentials (auth.json).
+      // If auth.json is missing or incomplete, we MUST NOT fall back to a
+      // placeholder userID — the Qoder gateway rejects requests with an
+      // unknown userID, returning HTTP 500 with no useful error detail.
+      // See: https://github.com/earendil-works/pi-provider-qoder/issues/XX
       const cachedCreds = getCachedCredentials(accessToken, model.provider);
-      const userID = cachedCreds?.userID || "qoder-user";
-      const name = cachedCreds?.name || (isQoderCNMode(providerMode) ? "Qoder CN User" : "Qoder User");
-      const email = cachedCreds?.email || getQoderUserEmailFallback(providerMode);
-      const machineID = cachedCreds?.machineID || getMachineId();
+      if (!cachedCreds?.userID) {
+        const providerLabel = isQoderCNMode(providerMode) ? "Qoder CN" : "Qoder";
+        throw new Error(
+          `${providerLabel} credentials file (~/.pi/agent/auth.json) is missing or does not contain userID. ` +
+            `Please re-login with "/login ${isQoderCNMode(providerMode) ? "qoder-cn" : "qoder"}" to regenerate it.`,
+        );
+      }
+      const userID = cachedCreds.userID;
+      const name = cachedCreds.name || (isQoderCNMode(providerMode) ? "Qoder CN User" : "Qoder User");
+      const email = cachedCreds.email || getQoderUserEmailFallback(providerMode);
+      const machineID = cachedCreds.machineID || getMachineId();
 
       const qoderModel = isQoderCNMode(providerMode) ? getQoderCNDirectModel(model.id) : model.id;
       const modelConfig = getCachedModelConfig(qoderModel, providerMode) || {


### PR DESCRIPTION
## 问题

当 `~/.pi/agent/auth.json` 不存在或不包含 `userID` 字段时，provider 会 fallback 到硬编码的 `"qoder-user"`。Qoder 网关拒绝该假 ID，返回 HTTP 500 `Internal Server Error`，且错误信息没有有用提示。

这导致所有 Qoder CN 模型（包括 auto/qwen3.7-max/deepseek-v4-pro 等 9 个模型）全部返回 500。

## 修复

1. **stream.ts**: 移除 `userID` fallback。当 `auth.json` 缺失或不含 `userID` 时，抛出明确错误提示用户重新登录（`/login qoder-cn`）
2. **index.ts**: `session_start` 刷新模型缓存时，若无法获取真实 `userID` 则跳过（`continue`），而非使用假值触发 500

## 验证

- [x] `npm run check` TypeScript 通过
- [x] `npm run lint` Biome 通过  
- [x] `npm test` 98/98 测试通过

## 影响范围

- 仅影响凭证读取路径，不改变正常登录用户的行为
- 之前静默失败（500）变为显式报错 + 修复指引