### PR TITLE
feat(vpc): 支持 VPC 部署的 qoder-cn（含身份解析韧性）

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,41 @@ Setting a CN PAT without a global PAT also auto-selects CN mode for the `qoder`
 entry, but the recommended explicit China entry is still `/login qoder-cn` and
 `--provider qoder-cn`.
 
+### Enterprise VPC
+
+Set the VPC instance name shown before `.vpc.qoder.com.cn`:
+
+```bash
+export QODER_VPC_INSTANCE=sungrow-of-enterprise
+```
+
+The provider derives the service-specific hosts expected by Qoder VPC:
+
+- `https://<instance>-gateway.vpc.qoder.com.cn`
+- `https://<instance>-openapi.vpc.qoder.com.cn`
+
+`QODER_VPC_ENDPOINT` and the official CLI variable `QODERCN_VPC_ENDPOINT`
+are accepted as aliases. The legacy `QODERCN_CLI_VPC_ENDPOINT` spelling is
+also accepted. Existing `QODER_CN_BASE_URL`,
+`QODER_CN_OPENAPI_URL`, and `QODER_CN_CENTER_URL` overrides remain supported;
+when they contain the tenant dashboard host, the provider normalizes them to
+the corresponding gateway or OpenAPI host.
+
+Important: `<instance>.vpc.qoder.com.cn` is the tenant dashboard host, not an
+API host. Sending PAT exchange or COSY chat there returns `CSRFInvalid`
+because it hits web/session middleware. Always use the derived `-gateway` /
+`-openapi` hosts above.
+
+Use a PAT created by the VPC tenant (for example from
+`https://<instance>.vpc.qoder.com.cn/account/integrations`). A public/global
+PAT exchanged against the tenant OpenAPI host fails with
+`open_access_token not found`. The exchange payload must remain
+`personal_token`; verify PAT provisioning with the tenant administrator.
+
+For safe request diagnostics, set `QODER_COSY_DEBUG=1`. Logs include the URL,
+status, and non-secret COSY signature inputs, but never credentials,
+Authorization, `Cosy-Key`, or machine identifiers.
+
 ## Endpoints
 
 Global:

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Qoder China:
 
 - Run `/login qoder-cn`, then paste the CN PAT.
 - Or set `QODERCN_PERSONAL_ACCESS_TOKEN` (or `QODERCN_PAT`) before starting pi.
+- `QODER_API_KEY` is accepted as a CN PAT alias **only** when the value starts with `pt-`.
 
 > The exchanged job token is short-lived; the provider transparently re-exchanges
 > the stored PAT when it expires.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "./node_modules/esbuild/bin/esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js --external:@earendil-works/pi-ai --external:@earendil-works/pi-coding-agent",
+    "build": "node node_modules/esbuild/bin/esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js --external:@earendil-works/pi-ai --external:@earendil-works/pi-coding-agent",
     "check": "node node_modules/typescript/bin/tsc --noEmit",
     "lint": "node node_modules/@biomejs/biome/bin/biome check .",
     "lint:fix": "node node_modules/@biomejs/biome/bin/biome check --write .",

--- a/src/__tests__/cosy.test.ts
+++ b/src/__tests__/cosy.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  formatQoderHttpError,
   getQoderBaseUrl,
   getQoderCenterUrl,
   getQoderChatURL,
@@ -17,6 +18,29 @@ import {
   isQoderCNMode,
   toQoderCNFriendlyModel,
 } from "../cosy.js";
+
+const endpointEnvNames = [
+  "QODER_CN_BASE_URL",
+  "QODER_CN_OPENAPI_URL",
+  "QODER_CN_CENTER_URL",
+  "QODER_VPC_INSTANCE",
+  "QODER_VPC_ENDPOINT",
+  "QODERCN_VPC_ENDPOINT",
+  "QODERCN_CLI_VPC_ENDPOINT",
+] as const;
+const originalEndpointEnv = Object.fromEntries(endpointEnvNames.map((name) => [name, process.env[name]]));
+
+beforeEach(() => {
+  for (const name of endpointEnvNames) delete process.env[name];
+});
+
+afterEach(() => {
+  for (const name of endpointEnvNames) {
+    const value = originalEndpointEnv[name];
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+});
 
 // ── getQoderMode ──────────────────────────────────────────────────────────
 
@@ -86,6 +110,62 @@ describe("getQoderCenterUrl", () => {
 
   it("returns global URL for global mode", () => {
     expect(getQoderCenterUrl("global")).toBe("https://center.qoder.sh");
+  });
+});
+
+describe("Qoder VPC endpoint derivation", () => {
+  it("derives gateway and OpenAPI hosts from an instance name", () => {
+    process.env.QODER_VPC_INSTANCE = "sungrow-of-enterprise";
+
+    expect(getQoderBaseUrl("cn")).toBe("https://sungrow-of-enterprise-gateway.vpc.qoder.com.cn/");
+    expect(getQoderOpenApiUrl("cn")).toBe("https://sungrow-of-enterprise-openapi.vpc.qoder.com.cn");
+    expect(getQoderCenterUrl("cn")).toBe("https://sungrow-of-enterprise-gateway.vpc.qoder.com.cn");
+  });
+
+  it("normalizes the tenant dashboard URL used as a legacy override", () => {
+    const dashboardUrl = "https://sungrow-of-enterprise.vpc.qoder.com.cn/";
+    process.env.QODER_CN_BASE_URL = dashboardUrl;
+
+    expect(getQoderBaseUrl("cn")).toBe("https://sungrow-of-enterprise-gateway.vpc.qoder.com.cn/");
+    expect(getQoderOpenApiUrl("cn")).toBe("https://sungrow-of-enterprise-openapi.vpc.qoder.com.cn");
+    expect(getQoderCenterUrl("cn")).toBe("https://sungrow-of-enterprise-gateway.vpc.qoder.com.cn");
+  });
+
+  it("accepts the official CLI VPC endpoint environment variable", () => {
+    process.env.QODERCN_VPC_ENDPOINT = "sungrow-of-enterprise-openapi.vpc.qoder.com.cn";
+
+    expect(getQoderBaseUrl("cn")).toBe("https://sungrow-of-enterprise-gateway.vpc.qoder.com.cn/");
+    expect(getQoderOpenApiUrl("cn")).toBe("https://sungrow-of-enterprise-openapi.vpc.qoder.com.cn");
+  });
+});
+
+describe("formatQoderHttpError", () => {
+  it("explains CSRFInvalid on the tenant dashboard host", () => {
+    const message = formatQoderHttpError(
+      "pat-exchange",
+      400,
+      "Bad Request",
+      '{"errorCode":"CSRFInvalid","errorMessage":"Invalid or missing CSRF token"}',
+      "https://sungrow-of-enterprise.vpc.qoder.com.cn/api/v1/jobToken/exchange",
+    );
+
+    expect(message).toContain("CSRFInvalid");
+    expect(message).toContain("tenant dashboard host");
+    expect(message).toContain("<instance>-gateway.vpc.qoder.com.cn");
+  });
+
+  it("explains open_access_token not found on the VPC OpenAPI host", () => {
+    const message = formatQoderHttpError(
+      "pat-exchange",
+      400,
+      "Bad Request",
+      '{"errorCode":"BadRequest","errorMessage":"openv1: open_access_token not found"}',
+      "https://sungrow-of-enterprise-openapi.vpc.qoder.com.cn/api/v1/jobToken/exchange",
+    );
+
+    expect(message).toContain("open_access_token not found");
+    expect(message).toContain("tenant-side access record");
+    expect(message).toContain("/account/integrations");
   });
 });
 

--- a/src/__tests__/cosy.test.ts
+++ b/src/__tests__/cosy.test.ts
@@ -6,7 +6,9 @@ import {
   getQoderChatURL,
   getQoderCNDirectModel,
   getQoderCNFriendlyModelInfo,
+  getQoderCNPat,
   getQoderExchangeURL,
+  getQoderIntegrationsUrl,
   getQoderManageUrl,
   getQoderMode,
   getQoderModelListURL,
@@ -16,6 +18,7 @@ import {
   getQoderUserEmailFallback,
   getQoderUserInfoURL,
   isQoderCNMode,
+  isQoderPatValue,
   toQoderCNFriendlyModel,
 } from "../cosy.js";
 
@@ -236,6 +239,44 @@ describe("getQoderManageUrl", () => {
 
   it("returns global URL", () => {
     expect(getQoderManageUrl("global")).toBe("https://qoder.com");
+  });
+
+  it("returns VPC tenant dashboard when QODER_VPC_INSTANCE is set", () => {
+    process.env.QODER_VPC_INSTANCE = "sungrow-of-enterprise";
+    expect(getQoderManageUrl("cn")).toBe("https://sungrow-of-enterprise.vpc.qoder.com.cn");
+  });
+});
+
+describe("getQoderIntegrationsUrl", () => {
+  it("points at public CN integrations by default", () => {
+    expect(getQoderIntegrationsUrl("cn")).toBe("https://qoder.com.cn/account/integrations");
+  });
+
+  it("points at VPC tenant integrations when instance is set", () => {
+    process.env.QODER_VPC_INSTANCE = "sungrow-of-enterprise";
+    expect(getQoderIntegrationsUrl("cn")).toBe(
+      "https://sungrow-of-enterprise.vpc.qoder.com.cn/account/integrations",
+    );
+  });
+});
+
+describe("getQoderCNPat / isQoderPatValue", () => {
+  it("prefers dedicated CN PAT env vars", () => {
+    process.env.QODERCN_PAT = "pt-dedicated";
+    process.env.QODER_API_KEY = "pt-alias";
+    expect(getQoderCNPat()).toBe("pt-dedicated");
+  });
+
+  it("accepts QODER_API_KEY only when it starts with pt-", () => {
+    process.env.QODER_API_KEY = "pt-from-api-key";
+    expect(isQoderPatValue(process.env.QODER_API_KEY)).toBe(true);
+    expect(getQoderCNPat()).toBe("pt-from-api-key");
+  });
+
+  it("ignores QODER_API_KEY when it is not a PAT", () => {
+    process.env.QODER_API_KEY = "jt-not-a-pat";
+    expect(isQoderPatValue(process.env.QODER_API_KEY)).toBe(false);
+    expect(getQoderCNPat()).toBe("");
   });
 });
 

--- a/src/__tests__/cosy.test.ts
+++ b/src/__tests__/cosy.test.ts
@@ -27,6 +27,15 @@ const endpointEnvNames = [
   "QODER_VPC_ENDPOINT",
   "QODERCN_VPC_ENDPOINT",
   "QODERCN_CLI_VPC_ENDPOINT",
+  // PAT env vars force CN mode in getQoderMode(); isolate tests from host env.
+  "QODERCN_PERSONAL_ACCESS_TOKEN",
+  "QODERCN_PAT",
+  "QODER_PERSONAL_ACCESS_TOKEN",
+  "QODER_PAT",
+  "QODER_API_KEY",
+  "QODER_REGION",
+  "QODER_BACKEND",
+  "QODER_MODE",
 ] as const;
 const originalEndpointEnv = Object.fromEntries(endpointEnvNames.map((name) => [name, process.env[name]]));
 

--- a/src/__tests__/cosy.test.ts
+++ b/src/__tests__/cosy.test.ts
@@ -8,6 +8,7 @@ import {
   getQoderCNFriendlyModelInfo,
   getQoderCNPat,
   getQoderExchangeURL,
+  getQoderJobTokenRefreshURL,
   getQoderIntegrationsUrl,
   getQoderManageUrl,
   getQoderMode,
@@ -207,6 +208,19 @@ describe("getQoderExchangeURL", () => {
 
   it("constructs correct global URL", () => {
     expect(getQoderExchangeURL("global")).toBe("https://openapi.qoder.sh/api/v1/jobToken/exchange");
+  });
+});
+
+describe("getQoderJobTokenRefreshURL", () => {
+  it("constructs correct CN URL", () => {
+    expect(getQoderJobTokenRefreshURL("cn")).toBe("https://openapi.qoder.com.cn/api/v1/jobToken/refresh");
+  });
+
+  it("constructs VPC URL when instance is set", () => {
+    process.env.QODER_VPC_INSTANCE = "sungrow-of-enterprise";
+    expect(getQoderJobTokenRefreshURL("cn")).toBe(
+      "https://sungrow-of-enterprise-openapi.vpc.qoder.com.cn/api/v1/jobToken/refresh",
+    );
   });
 });
 

--- a/src/__tests__/oauth.identity.test.ts
+++ b/src/__tests__/oauth.identity.test.ts
@@ -1,0 +1,318 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const AUTH_FILE = join(homedir(), ".pi", "agent", "auth.json");
+
+const { existsSyncMock, readFileSyncMock } = vi.hoisted(() => ({
+  existsSyncMock: vi.fn(),
+  readFileSyncMock: vi.fn(),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    existsSync: existsSyncMock,
+    readFileSync: readFileSyncMock,
+  };
+});
+
+import {
+  clearQoderIdentityMemoryCache,
+  getCachedCredentials,
+  peekQoderIdentityMemoryCache,
+  rememberQoderIdentity,
+  resolveQoderIdentity,
+} from "../oauth.js";
+
+const endpointEnvNames = [
+  "QODER_CN_BASE_URL",
+  "QODER_CN_OPENAPI_URL",
+  "QODER_CN_CENTER_URL",
+  "QODER_VPC_ENDPOINT",
+  "QODERCN_VPC_ENDPOINT",
+  "QODERCN_CLI_VPC_ENDPOINT",
+  "QODER_VPC_INSTANCE",
+  "QODERCN_PERSONAL_ACCESS_TOKEN",
+  "QODERCN_PAT",
+  "QODER_PERSONAL_ACCESS_TOKEN",
+  "QODER_PAT",
+  "QODER_API_KEY",
+] as const;
+const originalEndpointEnv = Object.fromEntries(endpointEnvNames.map((name) => [name, process.env[name]]));
+
+beforeEach(() => {
+  clearQoderIdentityMemoryCache();
+  existsSyncMock.mockReset();
+  readFileSyncMock.mockReset();
+  for (const name of endpointEnvNames) delete process.env[name];
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  clearQoderIdentityMemoryCache();
+  for (const name of endpointEnvNames) {
+    const original = originalEndpointEnv[name];
+    if (original === undefined) delete process.env[name];
+    else process.env[name] = original;
+  }
+});
+
+function stubEmptyAuthJson() {
+  existsSyncMock.mockImplementation((path: PathLike) => String(path) === AUTH_FILE);
+  readFileSyncMock.mockImplementation((path: PathLike) => {
+    if (String(path) === AUTH_FILE) return "{}";
+    throw new Error(`unexpected read: ${String(path)}`);
+  });
+}
+
+// local type alias without importing fs namespace (mocked)
+type PathLike = string | Buffer | URL;
+
+describe("getCachedCredentials", () => {
+  it("returns null when auth.json is empty", () => {
+    stubEmptyAuthJson();
+    expect(getCachedCredentials("jt-test", "qoder-cn")).toBeNull();
+  });
+
+  it("returns creds when auth.json userID matches this access token", () => {
+    existsSyncMock.mockImplementation((path: PathLike) => String(path) === AUTH_FILE);
+    readFileSyncMock.mockImplementation(() =>
+      JSON.stringify({
+        "qoder-cn": {
+          userID: "user-1",
+          email: "a@b.c",
+          name: "n",
+          machineID: "m-1",
+          access: "jt-x",
+          refresh: "pat|x|y|user-1|m-1",
+          expires: 1,
+        },
+      }),
+    );
+    const creds = getCachedCredentials("jt-x", "qoder-cn");
+    expect(creds?.userID).toBe("user-1");
+    expect(creds?.machineID).toBe("m-1");
+  });
+
+  it("returns null when auth.json access does not match the current token", () => {
+    existsSyncMock.mockImplementation((path: PathLike) => String(path) === AUTH_FILE);
+    readFileSyncMock.mockImplementation(() =>
+      JSON.stringify({
+        "qoder-cn": {
+          userID: "old-user",
+          email: "old@example.com",
+          name: "Old",
+          machineID: "m-old",
+          access: "jt-old",
+          refresh: "pat|x|y|old-user|m-old",
+          expires: 1,
+        },
+      }),
+    );
+    expect(getCachedCredentials("jt-new", "qoder-cn")).toBeNull();
+  });
+
+  it("returns null when auth.json has userID but no access field", () => {
+    existsSyncMock.mockImplementation((path: PathLike) => String(path) === AUTH_FILE);
+    readFileSyncMock.mockImplementation(() =>
+      JSON.stringify({
+        "qoder-cn": {
+          userID: "user-1",
+          email: "a@b.c",
+          name: "n",
+          machineID: "m-1",
+        },
+      }),
+    );
+    expect(getCachedCredentials("jt-x", "qoder-cn")).toBeNull();
+  });
+});
+
+describe("resolveQoderIdentity", () => {
+  it("uses auth.json fast path only when stored access matches", async () => {
+    existsSyncMock.mockImplementation((path: PathLike) => String(path) === AUTH_FILE);
+    readFileSyncMock.mockImplementation(() =>
+      JSON.stringify({
+        "qoder-cn": {
+          userID: "from-file",
+          email: "file@example.com",
+          name: "File User",
+          machineID: "machine-file",
+          access: "jt-access",
+        },
+      }),
+    );
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const identity = await resolveQoderIdentity("jt-access", "qoder-cn", "cn");
+    expect(identity.userID).toBe("from-file");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores stale auth.json and re-resolves via userinfo for a new access token", async () => {
+    existsSyncMock.mockImplementation((path: PathLike) => String(path) === AUTH_FILE);
+    readFileSyncMock.mockImplementation(() =>
+      JSON.stringify({
+        "qoder-cn": {
+          userID: "old-user",
+          email: "old@example.com",
+          name: "Old User",
+          machineID: "machine-old",
+          access: "jt-old",
+        },
+      }),
+    );
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: "new-user", email: "new@example.com", name: "New User" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const identity = await resolveQoderIdentity("jt-new", "qoder-cn", "cn");
+    expect(identity.userID).toBe("new-user");
+    expect(identity.email).toBe("new@example.com");
+    expect(identity.access).toBe("jt-new");
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to /userinfo when auth.json has no userID", async () => {
+    stubEmptyAuthJson();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: "user-from-info", email: "u@example.com", name: "Info" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const identity = await resolveQoderIdentity("jt-access", "qoder-cn", "cn");
+    expect(identity.userID).toBe("user-from-info");
+    expect(identity.email).toBe("u@example.com");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/api/v1/userinfo");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer jt-access");
+  });
+
+  it("caches identity in memory after userinfo success", async () => {
+    stubEmptyAuthJson();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: "cached-user" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const first = await resolveQoderIdentity("jt-access", "qoder-cn", "cn");
+    const second = await resolveQoderIdentity("jt-access", "qoder-cn", "cn");
+    expect(first.userID).toBe("cached-user");
+    expect(second.userID).toBe("cached-user");
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    const cached = peekQoderIdentityMemoryCache();
+    expect(cached).toHaveLength(1);
+    expect(cached[0]).toEqual({
+      userID: "cached-user",
+      email: expect.any(String),
+      name: expect.any(String),
+      machineID: expect.any(String),
+    });
+    expect(cached[0]).not.toHaveProperty("access");
+    expect(cached[0]).not.toHaveProperty("refresh");
+    expect(cached[0]).not.toHaveProperty("expires");
+  });
+
+  it("throws a clear error when auth.json and userinfo both lack userID", async () => {
+    stubEmptyAuthJson();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } })),
+    );
+
+    await expect(resolveQoderIdentity("jt-access", "qoder-cn", "cn")).rejects.toThrow(/identity unavailable/i);
+    await expect(resolveQoderIdentity("jt-access", "qoder-cn", "cn")).rejects.toThrow(/userinfo/i);
+  });
+
+  it("does not invent a placeholder userID on userinfo failure", async () => {
+    stubEmptyAuthJson();
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+    await expect(resolveQoderIdentity("jt-access", "qoder-cn", "cn")).rejects.toThrow(/identity unavailable/i);
+  });
+});
+
+describe("rememberQoderIdentity cache hygiene", () => {
+  it("stores identity fields only even when given full credentials with refresh/PAT", () => {
+    rememberQoderIdentity("qoder-cn", {
+      access: "jt-secret-access",
+      refresh: "pat|pt-secret|jrt-x|user-1|machine-1",
+      expires: 123,
+      userID: "user-1",
+      email: "a@b.c",
+      name: "n",
+      machineID: "machine-1",
+    } as any);
+
+    const cached = peekQoderIdentityMemoryCache();
+    expect(cached).toHaveLength(1);
+    expect(Object.keys(cached[0]).sort()).toEqual(["email", "machineID", "name", "userID"]);
+    expect(JSON.stringify(cached[0])).not.toContain("jt-secret-access");
+    expect(JSON.stringify(cached[0])).not.toContain("pt-secret");
+    expect(JSON.stringify(cached[0])).not.toContain("pat|");
+  });
+
+  it("clears prior provider entries when remembering a new access token", () => {
+    rememberQoderIdentity("qoder-cn", {
+      access: "jt-old",
+      userID: "old-user",
+      email: "old@example.com",
+      name: "Old",
+      machineID: "m-old",
+    });
+    rememberQoderIdentity("qoder-cn", {
+      access: "jt-new",
+      userID: "new-user",
+      email: "new@example.com",
+      name: "New",
+      machineID: "m-new",
+    });
+
+    const cached = peekQoderIdentityMemoryCache();
+    expect(cached).toHaveLength(1);
+    expect(cached[0].userID).toBe("new-user");
+    expect(cached[0]).not.toHaveProperty("access");
+    expect(cached[0]).not.toHaveProperty("refresh");
+  });
+
+  it("does not keep stale identity under an old access token after provider replace", async () => {
+    stubEmptyAuthJson();
+    rememberQoderIdentity("qoder-cn", {
+      access: "jt-old",
+      userID: "old-user",
+      email: "old@example.com",
+      name: "Old",
+      machineID: "m-old",
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: "fresh-user", email: "fresh@example.com", name: "Fresh" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Old token was replaced; resolving with a different access must not reuse old identity.
+    const identity = await resolveQoderIdentity("jt-new", "qoder-cn", "cn");
+    expect(identity.userID).toBe("fresh-user");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(peekQoderIdentityMemoryCache()).toHaveLength(1);
+    expect(peekQoderIdentityMemoryCache()[0].userID).toBe("fresh-user");
+  });
+});

--- a/src/__tests__/pat.test.ts
+++ b/src/__tests__/pat.test.ts
@@ -1,5 +1,29 @@
-import { describe, expect, it } from "vitest";
-import { decodePatRefresh, encodePatRefresh, isPatRefresh, PAT_REFRESH_PREFIX } from "../pat.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { decodePatRefresh, encodePatRefresh, exchangeJobToken, isPatRefresh, PAT_REFRESH_PREFIX } from "../pat.js";
+
+const endpointEnvNames = [
+  "QODER_CN_BASE_URL",
+  "QODER_CN_OPENAPI_URL",
+  "QODER_CN_CENTER_URL",
+  "QODER_VPC_ENDPOINT",
+  "QODERCN_VPC_ENDPOINT",
+  "QODERCN_CLI_VPC_ENDPOINT",
+  "QODER_VPC_INSTANCE",
+] as const;
+const originalEndpointEnv = Object.fromEntries(endpointEnvNames.map((name) => [name, process.env[name]]));
+
+beforeEach(() => {
+  for (const name of endpointEnvNames) delete process.env[name];
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  for (const name of endpointEnvNames) {
+    const original = originalEndpointEnv[name];
+    if (original === undefined) delete process.env[name];
+    else process.env[name] = original;
+  }
+});
 
 // ── isPatRefresh ──────────────────────────────────────────────────────────
 
@@ -65,5 +89,30 @@ describe("encodePatRefresh / decodePatRefresh roundtrip", () => {
 describe("PAT_REFRESH_PREFIX", () => {
   it('is "pat"', () => {
     expect(PAT_REFRESH_PREFIX).toBe("pat");
+  });
+});
+
+describe("exchangeJobToken", () => {
+  it("matches the official CLI VPC exchange payload", async () => {
+    process.env.QODER_VPC_INSTANCE = "example-tenant";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          token: "jt-test",
+          refresh_token: "jrt-test",
+          expires_in: 60_000,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await exchangeJobToken("pt-test", "cn");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://example-tenant-openapi.vpc.qoder.com.cn/api/v1/jobToken/exchange");
+    expect(JSON.parse(init.body as string)).toEqual({ personal_token: "pt-test" });
+    expect(JSON.parse(init.body as string)).not.toHaveProperty("open_access_token");
   });
 });

--- a/src/__tests__/pat.test.ts
+++ b/src/__tests__/pat.test.ts
@@ -1,5 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { credentialsFromPat, decodePatRefresh, encodePatRefresh, exchangeJobToken, isPatRefresh, PAT_REFRESH_PREFIX } from "../pat.js";
+import {
+  credentialsFromPat,
+  decodePatRefresh,
+  encodeJobRefresh,
+  encodePatRefresh,
+  exchangeJobToken,
+  isPatRefresh,
+  JRT_REFRESH_PREFIX,
+  PAT_REFRESH_PREFIX,
+  refreshJobToken,
+} from "../pat.js";
+import { getQoderJobTokenRefreshURL } from "../cosy.js";
+import { refreshQoderTokenCN } from "../oauth.js";
 
 const endpointEnvNames = [
   "QODER_CN_BASE_URL",
@@ -28,15 +40,20 @@ afterEach(() => {
 // ── isPatRefresh ──────────────────────────────────────────────────────────
 
 describe("isPatRefresh", () => {
-  it("returns true for PAT refresh strings", () => {
-    expect(isPatRefresh("pat|mytoken|refresh123|user1|machine1")).toBe(true);
+  it("returns true for legacy PAT refresh strings", () => {
+    expect(isPatRefresh("pat|pt-mytoken|jrt-123|user1|machine1")).toBe(true);
   });
 
-  it("returns true for minimal PAT prefix", () => {
+  it("returns true for jrt-only refresh strings", () => {
+    expect(isPatRefresh("jrt|jrt-123|user1|machine1")).toBe(true);
+  });
+
+  it("returns true for minimal prefixes", () => {
     expect(isPatRefresh("pat|")).toBe(true);
+    expect(isPatRefresh("jrt|")).toBe(true);
   });
 
-  it("returns false for non-PAT refresh strings", () => {
+  it("returns false for non-job refresh strings", () => {
     expect(isPatRefresh("some-other-refresh-token")).toBe(false);
     expect(isPatRefresh("refresh|user|machine")).toBe(false);
   });
@@ -48,41 +65,50 @@ describe("isPatRefresh", () => {
 
 // ── encodePatRefresh / decodePatRefresh ───────────────────────────────────
 
-describe("encodePatRefresh / decodePatRefresh roundtrip", () => {
-  it("encodes and decodes correctly", () => {
-    const encoded = encodePatRefresh("pt-abc123", "jrt-xyz", "user-42", "machine-7");
-    expect(encoded).toBe("pat|pt-abc123|jrt-xyz|user-42|machine-7");
+describe("encodeJobRefresh / decodePatRefresh", () => {
+  it("encodes jrt-only refresh without PAT", () => {
+    const encoded = encodeJobRefresh("jrt-xyz", "user-42", "machine-7");
+    expect(encoded).toBe("jrt|jrt-xyz|user-42|machine-7");
+    expect(encoded).not.toContain("pt-");
 
     const decoded = decodePatRefresh(encoded);
+    expect(decoded).toEqual({
+      pat: "",
+      jobRefreshToken: "jrt-xyz",
+      userID: "user-42",
+      machineID: "machine-7",
+      legacyEmbeddedPat: false,
+    });
+  });
+
+  it("encodePatRefresh ignores PAT and emits jrt-only", () => {
+    const encoded = encodePatRefresh("pt-abc123", "jrt-xyz", "user-42", "machine-7");
+    expect(encoded).toBe("jrt|jrt-xyz|user-42|machine-7");
+    expect(encoded).not.toContain("pt-abc123");
+  });
+
+  it("decodes legacy pat|pt|jrt|user|machine format", () => {
+    const decoded = decodePatRefresh("pat|pt-abc123|jrt-xyz|user-42|machine-7");
     expect(decoded).toEqual({
       pat: "pt-abc123",
       jobRefreshToken: "jrt-xyz",
       userID: "user-42",
       machineID: "machine-7",
+      legacyEmbeddedPat: true,
     });
   });
 
-  it("handles empty fields", () => {
-    const encoded = encodePatRefresh("", "", "", "");
-    expect(encoded).toBe("pat||||");
-
+  it("handles empty jrt fields", () => {
+    const encoded = encodeJobRefresh("", "", "");
+    expect(encoded).toBe("jrt|||");
     const decoded = decodePatRefresh(encoded);
     expect(decoded).toEqual({
       pat: "",
       jobRefreshToken: "",
       userID: "",
       machineID: "",
+      legacyEmbeddedPat: false,
     });
-  });
-
-  it("handles pipe characters in fields gracefully", () => {
-    // The decode splits on |, so extra pipes shift fields
-    const encoded = encodePatRefresh("pt-test", "jrt-ok", "u1", "m1");
-    const decoded = decodePatRefresh(encoded);
-    expect(decoded.pat).toBe("pt-test");
-    expect(decoded.jobRefreshToken).toBe("jrt-ok");
-    expect(decoded.userID).toBe("u1");
-    expect(decoded.machineID).toBe("m1");
   });
 });
 
@@ -170,6 +196,95 @@ describe("credentialsFromPat", () => {
     const creds = await credentialsFromPat("pt-test", "cn");
     expect((creds as { userID?: string }).userID).toBe("user-ok");
     expect(creds.access).toBe("jt-ok");
-    expect(creds.refresh.startsWith("pat|pt-test|jrt-ok|user-ok|")).toBe(true);
+    expect(creds.refresh.startsWith("jrt|jrt-ok|user-ok|")).toBe(true);
+    expect(creds.refresh).not.toContain("pt-test");
+    expect(creds.refresh.split("|").some((p) => p.startsWith("pt-"))).toBe(false);
+  });
+});
+
+describe("refreshJobToken", () => {
+  it("posts refresh_token to the VPC jobToken refresh endpoint", async () => {
+    process.env.QODER_VPC_INSTANCE = "example-tenant";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          token: "jt-new",
+          refresh_token: "jrt-new",
+          expires_in: 3600000,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await refreshJobToken("jrt-old", "cn");
+    expect(result.jobToken).toBe("jt-new");
+    expect(result.jobRefreshToken).toBe("jrt-new");
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://example-tenant-openapi.vpc.qoder.com.cn/api/v1/jobToken/refresh");
+    expect(url).toBe(getQoderJobTokenRefreshURL("cn"));
+    expect(JSON.parse(init.body as string)).toEqual({ refresh_token: "jrt-old" });
+  });
+});
+
+describe("refreshQoderTokenCN without persisting PAT", () => {
+  it("refreshes via jrt and returns credentials without pt-", async () => {
+    process.env.QODER_VPC_INSTANCE = "example-tenant";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          token: "jt-refreshed",
+          refresh_token: "jrt-rotated",
+          expires_in: 3600000,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const refreshed = await refreshQoderTokenCN({
+      access: "jt-old",
+      refresh: "jrt|jrt-old|user-1|machine-1",
+      expires: Date.now() - 1000,
+      userID: "user-1",
+      email: "u@example.com",
+      name: "User",
+      machineID: "machine-1",
+    } as any);
+
+    expect(refreshed.access).toBe("jt-refreshed");
+    expect(refreshed.refresh).toBe("jrt|jrt-rotated|user-1|machine-1");
+    expect(refreshed.refresh.split("|").some((p) => p.startsWith("pt-"))).toBe(false);
+    expect(JSON.stringify(refreshed)).not.toContain("pt-");
+  });
+
+  it("migrates legacy pat|pt|jrt refresh to jrt-only via env-less jrt path", async () => {
+    process.env.QODER_VPC_INSTANCE = "example-tenant";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          token: "jt-from-jrt",
+          refresh_token: "jrt-from-jrt",
+          expires_in: 3600000,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const refreshed = await refreshQoderTokenCN({
+      access: "jt-old",
+      refresh: "pat|pt-should-not-persist|jrt-legacy|user-1|machine-1",
+      expires: Date.now() - 1000,
+      userID: "user-1",
+      email: "u@example.com",
+      name: "User",
+      machineID: "machine-1",
+    } as any);
+
+    expect(refreshed.access).toBe("jt-from-jrt");
+    expect(refreshed.refresh).toBe("jrt|jrt-from-jrt|user-1|machine-1");
+    expect(refreshed.refresh).not.toContain("pt-should-not-persist");
+    expect(JSON.stringify(refreshed)).not.toContain("pt-should-not-persist");
   });
 });

--- a/src/__tests__/pat.test.ts
+++ b/src/__tests__/pat.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { decodePatRefresh, encodePatRefresh, exchangeJobToken, isPatRefresh, PAT_REFRESH_PREFIX } from "../pat.js";
+import { credentialsFromPat, decodePatRefresh, encodePatRefresh, exchangeJobToken, isPatRefresh, PAT_REFRESH_PREFIX } from "../pat.js";
 
 const endpointEnvNames = [
   "QODER_CN_BASE_URL",
@@ -114,5 +114,62 @@ describe("exchangeJobToken", () => {
     expect(url).toBe("https://example-tenant-openapi.vpc.qoder.com.cn/api/v1/jobToken/exchange");
     expect(JSON.parse(init.body as string)).toEqual({ personal_token: "pt-test" });
     expect(JSON.parse(init.body as string)).not.toHaveProperty("open_access_token");
+  });
+});
+
+
+describe("credentialsFromPat", () => {
+  it("fails fast when userinfo returns empty userID", async () => {
+    process.env.QODER_VPC_INSTANCE = "example-tenant";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            token: "jt-test",
+            refresh_token: "jrt-test",
+            expires_in: 60_000,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ email: "x@y.z" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(credentialsFromPat("pt-test", "cn")).rejects.toThrow(/userinfo did not return userID/i);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns credentials when userinfo includes userID", async () => {
+    process.env.QODER_VPC_INSTANCE = "example-tenant";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            token: "jt-ok",
+            refresh_token: "jrt-ok",
+            expires_in: 60_000,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: "user-ok", email: "ok@example.com", name: "Ok" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const creds = await credentialsFromPat("pt-test", "cn");
+    expect((creds as { userID?: string }).userID).toBe("user-ok");
+    expect(creds.access).toBe("jt-ok");
+    expect(creds.refresh.startsWith("pat|pt-test|jrt-ok|user-ok|")).toBe(true);
   });
 });

--- a/src/cosy.ts
+++ b/src/cosy.ts
@@ -62,8 +62,20 @@ export function isQoderCNMode(modeOverride?: string): boolean {
   return getQoderMode(modeOverride) === "cn";
 }
 
+/** True when value looks like a Qoder PAT (pt-...), not a job token / opaque key. */
+export function isQoderPatValue(value?: string): boolean {
+  return Boolean(value?.trim().startsWith("pt-"));
+}
+
+/**
+ * Resolve a Qoder CN PAT from the environment.
+ * Accepts QODER_API_KEY only when it is a PAT (`pt-...`) — never treat jt-/opaque keys as PATs.
+ */
 export function getQoderCNPat(): string {
-  return process.env.QODERCN_PERSONAL_ACCESS_TOKEN || process.env.QODERCN_PAT || "";
+  const dedicated = process.env.QODERCN_PERSONAL_ACCESS_TOKEN || process.env.QODERCN_PAT || "";
+  if (dedicated.trim()) return dedicated.trim();
+  const apiKey = process.env.QODER_API_KEY || "";
+  return isQoderPatValue(apiKey) ? apiKey.trim() : "";
 }
 
 const QoderVPCDomain = "vpc.qoder.com.cn";
@@ -217,8 +229,19 @@ export function toQoderCNFriendlyModel<T extends { id: string; name: string }>(m
   };
 }
 
+/** Public or VPC tenant dashboard origin (no trailing slash). */
 export function getQoderManageUrl(mode?: string): string {
-  return isQoderCNMode(mode) ? "https://qoder.com.cn" : "https://qoder.com";
+  if (isQoderCNMode(mode)) {
+    const instance = getQoderVPCInstance();
+    if (instance) return `https://${instance}.${QoderVPCDomain}`;
+    return "https://qoder.com.cn";
+  }
+  return "https://qoder.com";
+}
+
+/** Where users create/copy a PAT (public CN or VPC tenant integrations page). */
+export function getQoderIntegrationsUrl(mode?: string): string {
+  return `${getQoderManageUrl(mode)}/account/integrations`;
 }
 
 export function getQoderUserEmailFallback(mode?: string): string {

--- a/src/cosy.ts
+++ b/src/cosy.ts
@@ -159,6 +159,10 @@ export function getQoderExchangeURL(mode?: string): string {
   return `${getQoderOpenApiUrl(mode)}/api/v1/jobToken/exchange`;
 }
 
+export function getQoderJobTokenRefreshURL(mode?: string): string {
+  return `${getQoderOpenApiUrl(mode)}/api/v1/jobToken/refresh`;
+}
+
 export function getQoderUserInfoURL(mode?: string): string {
   return `${getQoderOpenApiUrl(mode)}/api/v1/userinfo`;
 }

--- a/src/cosy.ts
+++ b/src/cosy.ts
@@ -66,16 +66,73 @@ export function getQoderCNPat(): string {
   return process.env.QODERCN_PERSONAL_ACCESS_TOKEN || process.env.QODERCN_PAT || "";
 }
 
-export function getQoderBaseUrl(mode?: string): string {
-  return isQoderCNMode(mode) ? "https://gateway.qoder.com.cn/" : "https://api3.qoder.sh/";
+const QoderVPCDomain = "vpc.qoder.com.cn";
+
+function parseQoderVPCInstance(value?: string): string | undefined {
+  if (!value?.trim()) return undefined;
+
+  let candidate = value.trim().toLowerCase();
+  try {
+    candidate = new URL(candidate.includes("://") ? candidate : `https://${candidate}`).hostname;
+  } catch {
+    return undefined;
+  }
+
+  const suffix = `.${QoderVPCDomain}`;
+  if (candidate.endsWith(suffix)) {
+    candidate = candidate.slice(0, -suffix.length);
+    if (candidate.endsWith("-gateway") || candidate.endsWith("-openapi")) {
+      candidate = candidate.slice(0, -8);
+    }
+  } else if (candidate.includes(".")) {
+    return undefined;
+  }
+
+  return /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(candidate) ? candidate : undefined;
 }
 
+function getQoderVPCInstance(endpointOverride?: string): string | undefined {
+  return parseQoderVPCInstance(
+    endpointOverride ||
+      process.env.QODER_VPC_INSTANCE ||
+      process.env.QODER_VPC_ENDPOINT ||
+      process.env.QODERCN_VPC_ENDPOINT ||
+      process.env.QODERCN_CLI_VPC_ENDPOINT ||
+      process.env.QODER_CN_BASE_URL ||
+      process.env.QODER_CN_OPENAPI_URL ||
+      process.env.QODER_CN_CENTER_URL,
+  );
+}
+
+function getQoderVPCServiceUrl(service: "gateway" | "openapi", endpointOverride?: string): string | undefined {
+  const instance = getQoderVPCInstance(endpointOverride);
+  return instance ? `https://${instance}-${service}.${QoderVPCDomain}` : undefined;
+}
+
+export function getQoderBaseUrl(mode?: string): string {
+  if (isQoderCNMode(mode)) {
+    const override = process.env.QODER_CN_BASE_URL;
+    const url = getQoderVPCServiceUrl("gateway", override) || override || "https://gateway.qoder.com.cn/";
+    return url.endsWith("/") ? url : `${url}/`;
+  }
+  return "https://api3.qoder.sh/";
+}
 export function getQoderOpenApiUrl(mode?: string): string {
-  return isQoderCNMode(mode) ? "https://openapi.qoder.com.cn" : "https://openapi.qoder.sh";
+  if (isQoderCNMode(mode)) {
+    const override = process.env.QODER_CN_OPENAPI_URL;
+    const url = getQoderVPCServiceUrl("openapi", override) || override || "https://openapi.qoder.com.cn";
+    return url.replace(/\/+$/, "");
+  }
+  return "https://openapi.qoder.sh";
 }
 
 export function getQoderCenterUrl(mode?: string): string {
-  return isQoderCNMode(mode) ? "https://gateway.qoder.com.cn" : "https://center.qoder.sh";
+  if (isQoderCNMode(mode)) {
+    const override = process.env.QODER_CN_CENTER_URL;
+    const url = getQoderVPCServiceUrl("gateway", override) || override || "https://gateway.qoder.com.cn";
+    return url.replace(/\/+$/, "");
+  }
+  return "https://center.qoder.sh";
 }
 
 export function getQoderModelListURL(mode?: string): string {
@@ -283,4 +340,118 @@ export function buildAuthHeaders(
     "Login-Version": QoderLoginVersion,
     "X-Request-Id": crypto.randomUUID(),
   };
+}
+
+function isCosyDebugEnabled(): boolean {
+  return ["1", "true", "yes", "on"].includes((process.env.QODER_COSY_DEBUG || "").toLowerCase());
+}
+
+export function logCosyRequest(method: string, requestURL: string, headers: Record<string, string>): void {
+  if (!isCosyDebugEnabled()) return;
+
+  console.error(
+    `[qoder:cosy] request ${JSON.stringify({
+      method,
+      url: requestURL,
+      cosyDate: headers["Cosy-Date"],
+      cosySigpath: headers["Cosy-Sigpath"],
+      cosyBodyhash: headers["Cosy-Bodyhash"],
+      cosyBodylength: headers["Cosy-Bodylength"],
+      cosyOrganizationId: headers["Cosy-Organization-Id"],
+      cosyOrganizationTags: headers["Cosy-Organization-Tags"],
+    })}`,
+  );
+}
+
+export async function logCosyResponse(requestURL: string, response: Response): Promise<void> {
+  if (!isCosyDebugEnabled()) return;
+
+  let bodyPreview: string | undefined;
+  if (!response.ok) {
+    try {
+      bodyPreview = (await response.clone().text()).slice(0, 200);
+    } catch {
+      bodyPreview = "<unavailable>";
+    }
+  }
+
+  const responseHeaders: Record<string, string> = {};
+  for (const name of [
+    "date",
+    "server",
+    "via",
+    "x-request-id",
+    "x-cosy-request-id",
+    "x-trace-id",
+    "trace-id",
+    "cf-ray",
+    "x-cache",
+    "x-envoy-upstream-service-time",
+  ]) {
+    const value = response.headers.get(name);
+    if (value !== null) responseHeaders[name] = value;
+  }
+
+  console.error(
+    `[qoder:cosy] response ${JSON.stringify({
+      url: requestURL,
+      status: response.status,
+      statusText: response.statusText,
+      headers: responseHeaders,
+      ...(bodyPreview === undefined ? {} : { bodyPreview }),
+    })}`,
+  );
+}
+
+function isQoderTenantDashboardHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  const suffix = `.${QoderVPCDomain}`;
+  if (!host.endsWith(suffix)) return false;
+  const prefix = host.slice(0, -suffix.length);
+  return Boolean(prefix) && !prefix.includes(".") && !prefix.endsWith("-gateway") && !prefix.endsWith("-openapi");
+}
+
+/** Enrich Qoder HTTP failures with VPC/CSRF guidance without leaking secrets. */
+export function formatQoderHttpError(
+  kind: "api" | "pat-exchange",
+  status: number,
+  statusText: string,
+  bodyText: string,
+  requestURL?: string,
+): string {
+  const preview = bodyText.replace(/\s+/g, " ").trim().slice(0, 200);
+  const prefix =
+    kind === "pat-exchange"
+      ? `Qoder PAT exchange failed: ${status} ${statusText}`
+      : `Qoder API request failed: ${status} ${statusText}`;
+  const base = preview ? `${prefix}. Response: ${preview}` : prefix;
+
+  let host = "";
+  if (requestURL) {
+    try {
+      host = new URL(requestURL).hostname.toLowerCase();
+    } catch {
+      host = "";
+    }
+  }
+
+  const hints: string[] = [];
+  if (/CSRFInvalid/i.test(bodyText)) {
+    if (host && isQoderTenantDashboardHost(host)) {
+      hints.push(
+        `Request hit the tenant dashboard host (${host}). Use the derived API hosts instead: https://<instance>-gateway.vpc.qoder.com.cn and https://<instance>-openapi.vpc.qoder.com.cn (set QODER_VPC_INSTANCE=<instance>).`,
+      );
+    } else {
+      hints.push(
+        "CSRFInvalid usually means the request reached web/session middleware instead of the VPC gateway/OpenAPI service. Set QODER_VPC_INSTANCE (or QODERCN_VPC_ENDPOINT) and retry with QODER_COSY_DEBUG=1.",
+      );
+    }
+  }
+  if (/open_access_token not found/i.test(bodyText)) {
+    hints.push(
+      "The VPC OpenAPI host could not resolve a tenant-side access record for this PAT. Create/use a PAT from the VPC tenant dashboard (https://<instance>.vpc.qoder.com.cn/account/integrations).",
+    );
+  }
+
+  return hints.length > 0 ? `${base} Hint: ${hints.join(" ")}` : base;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {
   toQoderCNFriendlyModel,
 } from "./cosy.js";
 import { getCachedModels, isCacheStale, staticCnModels, staticModels, updateQoderModelsCache } from "./models.js";
-import { getCachedCredentials, loginQoder, loginQoderCN, refreshQoderToken, refreshQoderTokenCN } from "./oauth.js";
+import { loginQoder, loginQoderCN, refreshQoderToken, refreshQoderTokenCN, resolveQoderIdentity } from "./oauth.js";
 import { streamQoder } from "./stream.js";
 import { fetchQoderUsage, fetchQoderUsageCN } from "./usage.js";
 
@@ -70,9 +70,8 @@ export default function (pi: ExtensionAPI) {
       try {
         const accessToken = await ctx.modelRegistry.getApiKeyForProvider(providerID);
         if (!accessToken || !isCacheStale(mode)) continue;
-        const creds = getCachedCredentials(accessToken, providerID);
-        // Skip model cache refresh if we cannot resolve a real userID.
-        // Calling the Qoder gateway with a placeholder userID causes HTTP 500.
+        // Prefer auth.json, else /userinfo(access). Never use a placeholder userID.
+        const creds = await resolveQoderIdentity(accessToken, providerID, mode);
         if (!creds?.userID) continue;
         const userID = creds.userID;
         const name = creds.name || (isQoderCNMode(mode) ? "Qoder CN User" : "Qoder User");

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,9 +71,12 @@ export default function (pi: ExtensionAPI) {
         const accessToken = await ctx.modelRegistry.getApiKeyForProvider(providerID);
         if (!accessToken || !isCacheStale(mode)) continue;
         const creds = getCachedCredentials(accessToken, providerID);
-        const userID = creds?.userID || "qoder-user";
-        const name = creds?.name || (isQoderCNMode(mode) ? "Qoder CN User" : "Qoder User");
-        const email = creds?.email || getQoderUserEmailFallback(mode);
+        // Skip model cache refresh if we cannot resolve a real userID.
+        // Calling the Qoder gateway with a placeholder userID causes HTTP 500.
+        if (!creds?.userID) continue;
+        const userID = creds.userID;
+        const name = creds.name || (isQoderCNMode(mode) ? "Qoder CN User" : "Qoder User");
+        const email = creds.email || getQoderUserEmailFallback(mode);
         await updateQoderModelsCache(accessToken, userID, name, email, mode);
       } catch {
         // Best-effort: fall back to the existing cache / static models.

--- a/src/login.ts
+++ b/src/login.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 import type { OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
-import { getMachineId, getQoderMode, isQoderCNMode } from "./cosy.js";
+import { getMachineId, getQoderIntegrationsUrl, getQoderMode, isQoderCNMode } from "./cosy.js";
 import { credentialsFromPat } from "./pat.js";
 
 type PromptFn = (p: { message: string; placeholder?: string; allowEmpty?: boolean }) => Promise<string>;
@@ -59,7 +59,8 @@ export async function interactiveLogin(
 
   if (isQoderCNMode(mode)) {
     throw new Error(
-      "Qoder CN browser login is not supported here. Paste a Qoder CN PAT from https://qoder.com.cn/account/integrations or set QODERCN_PERSONAL_ACCESS_TOKEN.",
+      `Qoder CN browser login is not supported here. Paste a Qoder CN PAT from ${getQoderIntegrationsUrl(mode)} ` +
+        "or set QODERCN_PERSONAL_ACCESS_TOKEN / QODERCN_PAT (or QODER_API_KEY=pt-...).",
     );
   }
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -8,6 +8,8 @@ import {
   getQoderMode,
   getQoderModelListURL,
   isQoderCNMode,
+  logCosyRequest,
+  logCosyResponse,
 } from "./cosy.js";
 
 export const ZERO_COST = Object.freeze({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
@@ -422,6 +424,7 @@ export async function updateQoderModelsCache(
       name,
       email,
     });
+    logCosyRequest("GET", modelListURL, headers);
 
     const response = await fetch(modelListURL, {
       method: "GET",
@@ -430,6 +433,7 @@ export async function updateQoderModelsCache(
         ...headers,
       },
     });
+    await logCosyResponse(modelListURL, response);
 
     if (!response.ok) {
       return;

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -13,7 +13,14 @@ import {
 } from "./cosy.js";
 import { interactiveLogin } from "./login.js";
 import { updateQoderModelsCache } from "./models.js";
-import { credentialsFromPat, decodePatRefresh, fetchUserInfo, isPatRefresh } from "./pat.js";
+import {
+  credentialsFromJobTokens,
+  credentialsFromPat,
+  decodePatRefresh,
+  fetchUserInfo,
+  isPatRefresh,
+  refreshJobToken,
+} from "./pat.js";
 
 export interface QoderCredentials extends OAuthCredentials {
   userID: string;
@@ -35,7 +42,7 @@ const AUTH_FILE = join(homedir(), ".pi", "agent", "auth.json");
 /**
  * Process-local identity cache.
  * Key: providerID + SHA-256(accessToken). Value: identity fields only.
- * Never stores access/refresh (refresh may embed a plaintext PAT).
+ * Never stores access/refresh (refresh holds jrt + identity only).
  */
 const identityMemoryCache = new Map<string, QoderIdentity>();
 
@@ -239,24 +246,78 @@ export async function refreshQoderTokenCN(credentials: OAuthCredentials): Promis
 }
 
 async function refreshQoderTokenForMode(credentials: OAuthCredentials, mode: string): Promise<OAuthCredentials> {
-  // PAT-based credentials: re-exchange the stored PAT for a fresh job token.
+  // Job-token credentials: refresh via jrt. Never re-persist a plaintext PAT.
   if (isPatRefresh(credentials.refresh)) {
-    const { pat } = decodePatRefresh(credentials.refresh);
-    if (pat) {
-      try {
-        const refreshed = await credentialsFromPat(pat, mode);
-        const qCreds = refreshed as QoderCredentials;
+    const decoded = decodePatRefresh(credentials.refresh);
+    const prev = credentials as Partial<QoderCredentials>;
+    const userID = decoded.userID || prev.userID || "";
+    const machineID = decoded.machineID || prev.machineID || getMachineId();
+    const email = prev.email || "";
+    const name = prev.name || "";
+    const providerLabel = isQoderCNMode(mode) ? "Qoder CN" : "Qoder";
+
+    const finalize = (refreshed: OAuthCredentials): OAuthCredentials => {
+      if (typeof refreshed.refresh === "string") {
+        const parts = refreshed.refresh.split("|");
+        if (parts.some((part) => part.startsWith("pt-") || (decoded.pat && part === decoded.pat))) {
+          throw new Error(`${providerLabel} refresh refused to persist a plaintext PAT in refresh`);
+        }
+      }
+      const qCreds = refreshed as QoderCredentials;
+      if (qCreds.userID) {
         rememberQoderIdentity(providerIDForMode(mode), qCreds);
         updateQoderModelsCache(qCreds.access, qCreds.userID, qCreds.name, qCreds.email, mode).catch(() => {});
-        return refreshed;
+      }
+      return refreshed;
+    };
+
+    // 1) Preferred: server jrt refresh.
+    if (decoded.jobRefreshToken) {
+      try {
+        const exchange = await refreshJobToken(decoded.jobRefreshToken, mode);
+        return finalize(
+          credentialsFromJobTokens(
+            exchange,
+            {
+              userID: userID || (credentials as QoderCredentials).userID,
+              email,
+              name,
+              machineID,
+            },
+            mode,
+          ),
+        );
       } catch {
-        // Fall through to validity extension below.
+        // Fall through to one-shot env PAT / legacy migrate.
       }
     }
-    return {
-      ...credentials,
-      expires: Date.now() + 60 * 60 * 1000, // extend 1 hour to retry later
-    };
+
+    // 2) One-shot env PAT (not from persisted refresh).
+    const envPat = isQoderCNMode(mode)
+      ? getQoderCNPat()
+      : process.env.QODER_PERSONAL_ACCESS_TOKEN || process.env.QODER_PAT || "";
+    if (envPat) {
+      try {
+        return finalize(await credentialsFromPat(envPat, mode));
+      } catch {
+        // Fall through.
+      }
+    }
+
+    // 3) Legacy migrate: if an old refresh still embeds a PAT, use it once to
+    //    obtain jrt-only credentials — then never write the PAT back.
+    if (decoded.legacyEmbeddedPat && decoded.pat) {
+      try {
+        return finalize(await credentialsFromPat(decoded.pat, mode));
+      } catch {
+        // Fall through to hard failure.
+      }
+    }
+
+    throw new Error(
+      `${providerLabel} job token refresh failed. Re-login with "/login ${isQoderCNMode(mode) ? "qoder-cn" : "qoder"}". ` +
+        `PAT is no longer stored in refresh; set a PAT env var only for one-shot login, or paste it interactively.`,
+    );
   }
 
   const parts = credentials.refresh.split("|");

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -1,13 +1,29 @@
+import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
-import { getMachineId, getQoderCNPat, getQoderMode, getQoderRefreshURL, isQoderCNMode } from "./cosy.js";
+import {
+  getMachineId,
+  getQoderCNPat,
+  getQoderMode,
+  getQoderRefreshURL,
+  getQoderUserEmailFallback,
+  isQoderCNMode,
+} from "./cosy.js";
 import { interactiveLogin } from "./login.js";
 import { updateQoderModelsCache } from "./models.js";
-import { credentialsFromPat, decodePatRefresh, isPatRefresh } from "./pat.js";
+import { credentialsFromPat, decodePatRefresh, fetchUserInfo, isPatRefresh } from "./pat.js";
 
 export interface QoderCredentials extends OAuthCredentials {
+  userID: string;
+  email: string;
+  name: string;
+  machineID: string;
+}
+
+/** Identity-only fields kept in the process-local cache (never access/refresh/PAT). */
+export interface QoderIdentity {
   userID: string;
   email: string;
   name: string;
@@ -17,19 +33,79 @@ export interface QoderCredentials extends OAuthCredentials {
 const AUTH_FILE = join(homedir(), ".pi", "agent", "auth.json");
 
 /**
+ * Process-local identity cache.
+ * Key: providerID + SHA-256(accessToken). Value: identity fields only.
+ * Never stores access/refresh (refresh may embed a plaintext PAT).
+ */
+const identityMemoryCache = new Map<string, QoderIdentity>();
+
+function hashAccessToken(accessToken: string): string {
+  return createHash("sha256").update(accessToken).digest("hex");
+}
+
+function identityCacheKey(providerID: string, accessToken: string): string {
+  return `${providerID}\0${hashAccessToken(accessToken)}`;
+}
+
+function clearProviderIdentityCache(providerID: string): void {
+  const prefix = `${providerID}\0`;
+  for (const key of [...identityMemoryCache.keys()]) {
+    if (key.startsWith(prefix)) identityMemoryCache.delete(key);
+  }
+}
+
+function toQoderIdentity(
+  creds: Pick<QoderCredentials, "userID" | "email" | "name" | "machineID">,
+): QoderIdentity {
+  return {
+    userID: creds.userID,
+    email: creds.email || "",
+    name: creds.name || "",
+    machineID: creds.machineID || getMachineId(),
+  };
+}
+
+/**
+ * Seed / replace the in-process identity cache after login, refresh, or resolve.
+ * Stores identity fields only; clears prior entries for this provider so stale
+ * access-token keys (and any previously cached secrets) cannot linger.
+ */
+export function rememberQoderIdentity(
+  providerID: string,
+  creds: Pick<QoderCredentials, "access" | "userID" | "email" | "name" | "machineID">,
+): void {
+  if (!creds?.access || !creds?.userID) return;
+  clearProviderIdentityCache(providerID);
+  identityMemoryCache.set(identityCacheKey(providerID, creds.access), toQoderIdentity(creds));
+}
+
+/** Test helper: clear process-local identity cache. */
+export function clearQoderIdentityMemoryCache(): void {
+  identityMemoryCache.clear();
+}
+
+/** Test helper: inspect cached identity values (must never include access/refresh). */
+export function peekQoderIdentityMemoryCache(): QoderIdentity[] {
+  return [...identityMemoryCache.values()].map((v) => ({ ...v }));
+}
+
+/**
  * Read the Qoder identity (userID/email/name/machineID) from pi's own auth
- * store. pi persists the full OAuthCredentials there on login/refresh and keeps
- * it up to date, so there is no need to maintain a separate credentials cache.
+ * store. This is a sync fast path only.
  *
  * Note: the auth.json path/shape is a pi internal convention, not a public API.
- * This is best-effort and falls back to null so callers can use placeholders.
+ * Do not treat rewriting full access/refresh into auth.json as the primary fix —
+ * that races the host credential store.
  */
-export function getCachedCredentials(_accessToken: string, providerID = "qoder"): QoderCredentials | null {
+export function getCachedCredentials(accessToken: string, providerID = "qoder"): QoderCredentials | null {
   if (existsSync(AUTH_FILE)) {
     try {
       const auth = JSON.parse(readFileSync(AUTH_FILE, "utf-8"));
       const creds = auth?.[providerID] || (providerID === "qoder" ? auth?.qoder : null);
-      if (creds?.userID) {
+      // Only trust auth.json when it belongs to THIS access token.
+      // Otherwise OMP may have rotated to a new account/token while auth.json
+      // still holds a stale userID — mixing them causes opaque gateway 500s.
+      if (creds?.userID && typeof creds.access === "string" && creds.access === accessToken) {
         return creds as QoderCredentials;
       }
     } catch {}
@@ -37,17 +113,94 @@ export function getCachedCredentials(_accessToken: string, providerID = "qoder")
   return null;
 }
 
+/**
+ * Resolve Qoder identity for chat/COSY requests.
+ *
+ * Cold-start stream only has the access token (options.apiKey) — not refresh —
+ * so recovery must not depend on decoding the DB refresh field.
+ *
+ * Order:
+ * 1. auth.json fast path (sync) — only when stored access === accessToken
+ * 2. process-local memory cache keyed by (providerID, sha256(accessToken)); identity-only values
+ * 3. /userinfo with the access token
+ *
+ * Never invents a placeholder userID. Stale auth.json (old userID + new access)
+ * must miss the fast path and re-resolve via /userinfo.
+ */
+export async function resolveQoderIdentity(
+  accessToken: string,
+  providerID = "qoder",
+  mode?: string,
+): Promise<QoderCredentials> {
+  const resolvedMode = mode ?? (providerID === "qoder-cn" ? "cn" : getQoderMode());
+  const providerLabel = isQoderCNMode(resolvedMode) ? "Qoder CN" : "Qoder";
+
+  const fromFile = getCachedCredentials(accessToken, providerID);
+  if (fromFile?.userID) {
+    const identity = toQoderIdentity({
+      userID: fromFile.userID,
+      email: fromFile.email || getQoderUserEmailFallback(resolvedMode),
+      name: fromFile.name || (isQoderCNMode(resolvedMode) ? "Qoder CN User" : "Qoder User"),
+      machineID: fromFile.machineID || getMachineId(),
+    });
+    rememberQoderIdentity(providerID, { access: accessToken, ...identity });
+    return {
+      access: accessToken,
+      refresh: "",
+      expires: 0,
+      ...identity,
+    };
+  }
+
+  const cached = identityMemoryCache.get(identityCacheKey(providerID, accessToken));
+  if (cached?.userID) {
+    return {
+      access: accessToken,
+      refresh: "",
+      expires: 0,
+      ...cached,
+    };
+  }
+
+  const info = await fetchUserInfo(accessToken, resolvedMode);
+  if (!info.userID) {
+    throw new Error(
+      `${providerLabel} identity unavailable: ~/.pi/agent/auth.json has no userID and /userinfo did not return one. ` +
+        `Re-login with "/login ${isQoderCNMode(resolvedMode) ? "qoder-cn" : "qoder"}" ` +
+        `(VPC: ensure QODER_VPC_INSTANCE is set; do not use a placeholder userID).`,
+    );
+  }
+
+  const identity: QoderIdentity = {
+    userID: info.userID,
+    email: info.email || getQoderUserEmailFallback(resolvedMode),
+    name: info.name || (isQoderCNMode(resolvedMode) ? "Qoder CN User" : "Qoder User"),
+    machineID: getMachineId(),
+  };
+  rememberQoderIdentity(providerID, { access: accessToken, ...identity });
+  return {
+    access: accessToken,
+    refresh: "",
+    expires: 0,
+    ...identity,
+  };
+}
+
+function providerIDForMode(mode: string): string {
+  return isQoderCNMode(mode) ? "qoder-cn" : "qoder";
+}
+
 async function loginQoderForMode(callbacks: OAuthLoginCallbacks, mode: string): Promise<OAuthCredentials> {
   // 1. Try environment variables first (PAT). A PAT (pt-...) must be exchanged
   //    for a short-lived job token before it can be used — credentialsFromPat
-  //    handles the exchange + identity resolution.
+  //    handles the exchange + identity resolution (and fails if userID is empty).
   const pat = isQoderCNMode(mode) ? getQoderCNPat() : process.env.QODER_PERSONAL_ACCESS_TOKEN || process.env.QODER_PAT;
   if (pat) {
     try {
       const creds = await credentialsFromPat(pat, mode);
       const qCreds = creds as QoderCredentials;
-      // pi persists these credentials in auth.json itself; no separate cache needed.
-      // Cache models in background
+      rememberQoderIdentity(providerIDForMode(mode), qCreds);
+      // Host persists oauth credentials; we only keep identity in-process.
       updateQoderModelsCache(qCreds.access, qCreds.userID, qCreds.name, qCreds.email, mode).catch(() => {});
       return creds;
     } catch {
@@ -58,10 +211,12 @@ async function loginQoderForMode(callbacks: OAuthLoginCallbacks, mode: string): 
   // 2. Interactive login (CN only supports PAT prompt here; global supports device flow fallback)
   const creds = await interactiveLogin(callbacks, mode);
 
-  // Cache models in background. pi persists the credentials in auth.json itself.
   try {
     const qCreds = creds as QoderCredentials;
-    updateQoderModelsCache(qCreds.access, qCreds.userID, qCreds.name, qCreds.email, mode).catch(() => {});
+    if (qCreds.userID) {
+      rememberQoderIdentity(providerIDForMode(mode), qCreds);
+      updateQoderModelsCache(qCreds.access, qCreds.userID, qCreds.name, qCreds.email, mode).catch(() => {});
+    }
   } catch {}
 
   return creds;
@@ -91,6 +246,7 @@ async function refreshQoderTokenForMode(credentials: OAuthCredentials, mode: str
       try {
         const refreshed = await credentialsFromPat(pat, mode);
         const qCreds = refreshed as QoderCredentials;
+        rememberQoderIdentity(providerIDForMode(mode), qCreds);
         updateQoderModelsCache(qCreds.access, qCreds.userID, qCreds.name, qCreds.email, mode).catch(() => {});
         return refreshed;
       } catch {
@@ -152,11 +308,12 @@ async function refreshQoderTokenForMode(credentials: OAuthCredentials, mode: str
         email: prevEmail,
         name: prevName,
         machineID,
-      };
+      } as QoderCredentials;
 
-      // pi persists the refreshed credentials in auth.json itself.
-      // Cache models in background
-      updateQoderModelsCache(newAccess, userID, prevName, prevEmail, mode).catch(() => {});
+      if (userID) {
+        rememberQoderIdentity(providerIDForMode(mode), refreshed);
+        updateQoderModelsCache(newAccess, userID, prevName, prevEmail, mode).catch(() => {});
+      }
 
       return refreshed;
     }

--- a/src/pat.ts
+++ b/src/pat.ts
@@ -3,6 +3,7 @@ import {
   formatQoderHttpError,
   getMachineId,
   getQoderExchangeURL,
+  getQoderJobTokenRefreshURL,
   getQoderMode,
   getQoderUserEmailFallback,
   getQoderUserInfoURL,
@@ -12,10 +13,15 @@ import {
 const UA = "pi-provider-qoder";
 
 /**
- * Marker prefix used in the credential `refresh` field to identify PAT-based
- * credentials. Layout: `pat|<personalToken>|<jobRefreshToken>|<userID>|<machineID>`
+ * Marker prefixes used in the credential `refresh` field for job-token auth.
+ *
+ * Current (no plaintext PAT): `jrt|<jobRefreshToken>|<userID>|<machineID>`
+ * Legacy (must migrate away): `pat|<personalToken>|<jobRefreshToken>|<userID>|<machineID>`
+ *
+ * Never encode a `pt-...` PAT into refresh — the host persists this field.
  */
 export const PAT_REFRESH_PREFIX = "pat";
+export const JRT_REFRESH_PREFIX = "jrt";
 
 export interface PatExchangeResult {
   /** Short-lived job token (jt-...) used for auth + COSY signatures. */
@@ -32,27 +38,51 @@ export interface QoderUserInfo {
 }
 
 export function isPatRefresh(refresh: string): boolean {
-  return refresh.startsWith(`${PAT_REFRESH_PREFIX}|`);
+  return (
+    refresh.startsWith(`${JRT_REFRESH_PREFIX}|`) || refresh.startsWith(`${PAT_REFRESH_PREFIX}|`)
+  );
 }
 
-/** Encode a PAT credential's refresh field. */
+/** Encode job-token refresh WITHOUT embedding the plaintext PAT. */
+export function encodeJobRefresh(jobRefreshToken: string, userID: string, machineID: string): string {
+  return [JRT_REFRESH_PREFIX, jobRefreshToken, userID, machineID].join("|");
+}
+
+/**
+ * @deprecated Legacy encoder that embedded the PAT. Kept only so old tests/callers
+ * can be updated; new code must use encodeJobRefresh.
+ */
 export function encodePatRefresh(pat: string, jobRefreshToken: string, userID: string, machineID: string): string {
-  return [PAT_REFRESH_PREFIX, pat, jobRefreshToken, userID, machineID].join("|");
+  // Intentionally ignore `pat` — never persist plaintext PATs in refresh.
+  void pat;
+  return encodeJobRefresh(jobRefreshToken, userID, machineID);
 }
 
-/** Decode a PAT credential's refresh field. */
+/** Decode job-token / legacy PAT refresh fields. */
 export function decodePatRefresh(refresh: string): {
   pat: string;
   jobRefreshToken: string;
   userID: string;
   machineID: string;
+  legacyEmbeddedPat: boolean;
 } {
   const parts = refresh.split("|");
+  if (parts[0] === JRT_REFRESH_PREFIX) {
+    return {
+      pat: "",
+      jobRefreshToken: parts[1] || "",
+      userID: parts[2] || "",
+      machineID: parts[3] || "",
+      legacyEmbeddedPat: false,
+    };
+  }
+  // Legacy: pat|<pt>|<jrt>|<userID>|<machineID>
   return {
     pat: parts[1] || "",
     jobRefreshToken: parts[2] || "",
     userID: parts[3] || "",
     machineID: parts[4] || "",
+    legacyEmbeddedPat: Boolean(parts[1]),
   };
 }
 
@@ -109,6 +139,63 @@ export async function exchangeJobToken(pat: string, mode: string = getQoderMode(
 }
 
 /**
+ * Refresh a short-lived job token using the server-issued job refresh token (jrt-...).
+ * POST /api/v1/jobToken/refresh { refresh_token } -> { token, refresh_token, expires_at }
+ */
+export async function refreshJobToken(
+  jobRefreshToken: string,
+  mode: string = getQoderMode(),
+): Promise<PatExchangeResult> {
+  if (!jobRefreshToken?.trim()) {
+    throw new Error("Qoder job token refresh requires a non-empty refresh_token (jrt-...)");
+  }
+
+  const res = await fetch(getQoderJobTokenRefreshURL(mode), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      "User-Agent": UA,
+      "Cosy-Version": "1.0.1",
+      "Cosy-ClientType": "5",
+    },
+    body: JSON.stringify({ refresh_token: jobRefreshToken }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      formatQoderHttpError("pat-exchange", res.status, res.statusText, text, getQoderJobTokenRefreshURL(mode)),
+    );
+  }
+
+  const data = (await res.json()) as {
+    token?: string;
+    refresh_token?: string;
+    expires_at?: string;
+    expires_in?: number;
+  };
+
+  if (!data.token) {
+    throw new Error("Qoder job token refresh returned no job token");
+  }
+
+  let expiresAt = Date.now() + 24 * 60 * 60 * 1000;
+  if (data.expires_at) {
+    const parsed = Date.parse(data.expires_at);
+    if (!Number.isNaN(parsed)) expiresAt = parsed;
+  } else if (data.expires_in) {
+    expiresAt = Date.now() + data.expires_in;
+  }
+
+  return {
+    jobToken: data.token,
+    jobRefreshToken: data.refresh_token || jobRefreshToken,
+    expiresAt,
+  };
+}
+
+/**
  * Fetch user profile using a job/access token (jt-...).
  * Returns empty fields when the request fails; callers that require identity
  * (login) must fail-fast on empty userID.
@@ -146,8 +233,9 @@ export async function fetchUserInfo(jobToken: string, mode: string): Promise<Qod
 
 /**
  * Build full Qoder credentials from a Personal Access Token.
- * Exchanges the PAT for a job token, resolves identity, and encodes the PAT
- * into the refresh field so the token can be re-exchanged on expiry.
+ * Exchanges the PAT for a job token + job refresh token, resolves identity, and
+ * stores ONLY the jrt (+ identity) in `refresh`. The plaintext PAT is never
+ * written into credentials the host will persist.
  *
  * Fails if userinfo does not return a non-empty userID — otherwise login would
  * succeed while the first chat request fails with a missing-identity error.
@@ -162,15 +250,55 @@ export async function credentialsFromPat(pat: string, mode: string = getQoderMod
         : "Qoder login failed: userinfo did not return userID. Check network/PAT validity, then retry.",
     );
   }
+  if (!jobRefreshToken) {
+    throw new Error(
+      isQoderCNMode(mode)
+        ? "Qoder CN login failed: jobToken exchange returned no refresh_token (jrt). Cannot persist a refreshable session without embedding the PAT; retry or contact the tenant admin."
+        : "Qoder login failed: jobToken exchange returned no refresh_token (jrt). Cannot persist a refreshable session without embedding the PAT.",
+    );
+  }
   const machineID = getMachineId();
+  const refresh = encodeJobRefresh(jobRefreshToken, userID, machineID);
+  const refreshParts = refresh.split("|");
+  if (refreshParts.some((part) => part === pat || part.startsWith("pt-"))) {
+    throw new Error("Refusing to return credentials that embed a plaintext PAT in refresh");
+  }
 
   return {
-    refresh: encodePatRefresh(pat, jobRefreshToken, userID, machineID),
+    refresh,
     access: jobToken,
     expires: expiresAt - 5 * 60 * 1000, // 5 min buffer
     userID,
     email: email || getQoderUserEmailFallback(mode),
     name: name || (isQoderCNMode(mode) ? "Qoder CN User" : "Qoder User"),
+    machineID,
+  } as OAuthCredentials;
+}
+
+/**
+ * Build credentials from a job refresh token response / existing identity.
+ * Never accepts or stores a PAT.
+ */
+export function credentialsFromJobTokens(
+  exchange: PatExchangeResult,
+  identity: { userID: string; email?: string; name?: string; machineID?: string },
+  mode: string = getQoderMode(),
+): OAuthCredentials {
+  if (!identity.userID) {
+    throw new Error("Cannot build Qoder credentials without userID");
+  }
+  if (!exchange.jobRefreshToken) {
+    throw new Error("Cannot build refreshable Qoder credentials without jrt refresh_token");
+  }
+  const machineID = identity.machineID || getMachineId();
+  const refresh = encodeJobRefresh(exchange.jobRefreshToken, identity.userID, machineID);
+  return {
+    refresh,
+    access: exchange.jobToken,
+    expires: exchange.expiresAt - 5 * 60 * 1000,
+    userID: identity.userID,
+    email: identity.email || getQoderUserEmailFallback(mode),
+    name: identity.name || (isQoderCNMode(mode) ? "Qoder CN User" : "Qoder User"),
     machineID,
   } as OAuthCredentials;
 }

--- a/src/pat.ts
+++ b/src/pat.ts
@@ -25,6 +25,12 @@ export interface PatExchangeResult {
   expiresAt: number;
 }
 
+export interface QoderUserInfo {
+  userID: string;
+  email: string;
+  name: string;
+}
+
 export function isPatRefresh(refresh: string): boolean {
   return refresh.startsWith(`${PAT_REFRESH_PREFIX}|`);
 }
@@ -102,8 +108,12 @@ export async function exchangeJobToken(pat: string, mode: string = getQoderMode(
   };
 }
 
-/** Fetch user profile using a job token (jt-...). Best-effort. */
-async function fetchUserInfo(jobToken: string, mode: string): Promise<{ userID: string; email: string; name: string }> {
+/**
+ * Fetch user profile using a job/access token (jt-...).
+ * Returns empty fields when the request fails; callers that require identity
+ * (login) must fail-fast on empty userID.
+ */
+export async function fetchUserInfo(jobToken: string, mode: string): Promise<QoderUserInfo> {
   let userID = "";
   let email = "";
   let name = "";
@@ -128,7 +138,9 @@ async function fetchUserInfo(jobToken: string, mode: string): Promise<{ userID: 
       email = info.email || "";
       name = info.name || info.username || "";
     }
-  } catch {}
+  } catch {
+    // Callers decide whether empty identity is fatal.
+  }
   return { userID, email, name };
 }
 
@@ -136,10 +148,20 @@ async function fetchUserInfo(jobToken: string, mode: string): Promise<{ userID: 
  * Build full Qoder credentials from a Personal Access Token.
  * Exchanges the PAT for a job token, resolves identity, and encodes the PAT
  * into the refresh field so the token can be re-exchanged on expiry.
+ *
+ * Fails if userinfo does not return a non-empty userID — otherwise login would
+ * succeed while the first chat request fails with a missing-identity error.
  */
 export async function credentialsFromPat(pat: string, mode: string = getQoderMode()): Promise<OAuthCredentials> {
   const { jobToken, jobRefreshToken, expiresAt } = await exchangeJobToken(pat, mode);
   const { userID, email, name } = await fetchUserInfo(jobToken, mode);
+  if (!userID) {
+    throw new Error(
+      isQoderCNMode(mode)
+        ? "Qoder CN login failed: userinfo did not return userID. Check VPC routing (QODER_VPC_INSTANCE) and PAT validity, then retry."
+        : "Qoder login failed: userinfo did not return userID. Check network/PAT validity, then retry.",
+    );
+  }
   const machineID = getMachineId();
 
   return {

--- a/src/pat.ts
+++ b/src/pat.ts
@@ -1,5 +1,6 @@
 import type { OAuthCredentials } from "@earendil-works/pi-ai";
 import {
+  formatQoderHttpError,
   getMachineId,
   getQoderExchangeURL,
   getQoderMode,
@@ -71,7 +72,7 @@ export async function exchangeJobToken(pat: string, mode: string = getQoderMode(
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    throw new Error(`Qoder PAT exchange failed: ${res.status} ${res.statusText}. ${text.slice(0, 200)}`);
+    throw new Error(formatQoderHttpError("pat-exchange", res.status, res.statusText, text, getQoderExchangeURL(mode)));
   }
 
   const data = (await res.json()) as {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -113,12 +113,23 @@ export function streamQoder(
         );
       }
 
-      // Resolve user details from cached credentials
+      // Resolve user details from cached credentials (auth.json).
+      // If auth.json is missing or incomplete, we MUST NOT fall back to a
+      // placeholder userID — the Qoder gateway rejects requests with an
+      // unknown userID, returning HTTP 500 with no useful error detail.
+      // See: https://github.com/earendil-works/pi-provider-qoder/issues/XX
       const cachedCreds = getCachedCredentials(accessToken, model.provider);
-      const userID = cachedCreds?.userID || "qoder-user";
-      const name = cachedCreds?.name || (isQoderCNMode(providerMode) ? "Qoder CN User" : "Qoder User");
-      const email = cachedCreds?.email || getQoderUserEmailFallback(providerMode);
-      const machineID = cachedCreds?.machineID || getMachineId();
+      if (!cachedCreds?.userID) {
+        const providerLabel = isQoderCNMode(providerMode) ? "Qoder CN" : "Qoder";
+        throw new Error(
+          `${providerLabel} credentials file (~/.pi/agent/auth.json) is missing or does not contain userID. ` +
+            `Please re-login with "/login ${isQoderCNMode(providerMode) ? "qoder-cn" : "qoder"}" to regenerate it.`,
+        );
+      }
+      const userID = cachedCreds.userID;
+      const name = cachedCreds.name || (isQoderCNMode(providerMode) ? "Qoder CN User" : "Qoder User");
+      const email = cachedCreds.email || getQoderUserEmailFallback(providerMode);
+      const machineID = cachedCreds.machineID || getMachineId();
 
       const qoderModel = isQoderCNMode(providerMode) ? getQoderCNDirectModel(model.id) : model.id;
       const modelConfig = getCachedModelConfig(qoderModel, providerMode) || {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -111,7 +111,7 @@ export function streamQoder(
       if (!accessToken) {
         throw new Error(
           isQoderCNMode(providerMode)
-            ? "Qoder CN credentials not set. Run /login qoder-cn or set QODERCN_PERSONAL_ACCESS_TOKEN."
+            ? "Qoder CN credentials not set. Run /login qoder-cn or set QODERCN_PERSONAL_ACCESS_TOKEN / QODERCN_PAT (or QODER_API_KEY=pt-...)."
             : "Qoder credentials not set. Run /login qoder or set QODER_PERSONAL_ACCESS_TOKEN.",
         );
       }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -24,7 +24,7 @@ import {
   logCosyResponse,
 } from "./cosy.js";
 import { getCachedModelConfig } from "./models.js";
-import { getCachedCredentials } from "./oauth.js";
+import { resolveQoderIdentity } from "./oauth.js";
 import { qoderEncodeBody } from "./qoder-encoding.js";
 import { ThinkingTagParser } from "./thinking-parser.js";
 import { transformMessagesForQoder, transformTools } from "./transform.js";
@@ -116,23 +116,14 @@ export function streamQoder(
         );
       }
 
-      // Resolve user details from cached credentials (auth.json).
-      // If auth.json is missing or incomplete, we MUST NOT fall back to a
-      // placeholder userID — the Qoder gateway rejects requests with an
-      // unknown userID, returning HTTP 500 with no useful error detail.
-      // See: https://github.com/earendil-works/pi-provider-qoder/issues/XX
-      const cachedCreds = getCachedCredentials(accessToken, model.provider);
-      if (!cachedCreds?.userID) {
-        const providerLabel = isQoderCNMode(providerMode) ? "Qoder CN" : "Qoder";
-        throw new Error(
-          `${providerLabel} credentials file (~/.pi/agent/auth.json) is missing or does not contain userID. ` +
-            `Please re-login with "/login ${isQoderCNMode(providerMode) ? "qoder-cn" : "qoder"}" to regenerate it.`,
-        );
-      }
-      const userID = cachedCreds.userID;
-      const name = cachedCreds.name || (isQoderCNMode(providerMode) ? "Qoder CN User" : "Qoder User");
-      const email = cachedCreds.email || getQoderUserEmailFallback(providerMode);
-      const machineID = cachedCreds.machineID || getMachineId();
+      // Resolve identity: auth.json fast path → in-process cache → /userinfo(access).
+      // Cold start only has options.apiKey (access); do NOT decode refresh here.
+      // Never invent a placeholder userID — the gateway returns opaque HTTP 500.
+      const identity = await resolveQoderIdentity(accessToken, model.provider, providerMode);
+      const userID = identity.userID;
+      const name = identity.name || (isQoderCNMode(providerMode) ? "Qoder CN User" : "Qoder User");
+      const email = identity.email || getQoderUserEmailFallback(providerMode);
+      const machineID = identity.machineID || getMachineId();
 
       const qoderModel = isQoderCNMode(providerMode) ? getQoderCNDirectModel(model.id) : model.id;
       const modelConfig = getCachedModelConfig(qoderModel, providerMode) || {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -13,12 +13,15 @@ import type {
 import * as PiAi from "@earendil-works/pi-ai";
 import {
   buildAuthHeaders,
+  formatQoderHttpError,
   getMachineId,
   getQoderChatURL,
   getQoderCNDirectModel,
   getQoderMode,
   getQoderUserEmailFallback,
   isQoderCNMode,
+  logCosyRequest,
+  logCosyResponse,
 } from "./cosy.js";
 import { getCachedModelConfig } from "./models.js";
 import { getCachedCredentials } from "./oauth.js";
@@ -227,6 +230,7 @@ export function streamQoder(
         email,
         machineID,
       });
+      logCosyRequest("POST", chatURL, headers);
 
       const modelSource = modelConfig.source || "system";
 
@@ -244,10 +248,11 @@ export function streamQoder(
         body: encodedBytes,
         signal: options?.signal,
       });
+      await logCosyResponse(chatURL, response);
 
       if (!response.ok) {
         const errText = await response.text();
-        throw new Error(`Qoder API request failed: ${response.status} ${response.statusText}. Response: ${errText}`);
+        throw new Error(formatQoderHttpError("api", response.status, response.statusText, errText, chatURL));
       }
 
       const reader = response.body?.getReader();


### PR DESCRIPTION
## Summary

`vpc` 分支（原 `sungrow`）目标是让本 fork 支持 **VPC 部署的 `qoder-cn`**（例如 `QODER_VPC_INSTANCE=sungrow-of-enterprise`）。

本 PR 包含：

1. **VPC endpoints**：由 `QODER_VPC_INSTANCE` / `QODER*_VPC_ENDPOINT` 推导 `*-gateway` / `*-openapi`；禁止把租户 dashboard 当 API 主机。
2. **身份解析韧性（OMP 冷启动）**：
   - `auth.json` 无匹配 `userID` 时 async `/userinfo`
   - 仅当 `auth.json.access === accessToken` 走 fast path
   - 进程内缓存只存身份字段，key 用 `SHA-256(access)`
   - `credentialsFromPat` 空 `userID` fail-fast
   - 绝不使用 placeholder `userID`

> 注：原 PR #6 的 head 为 `sungrow`；GitHub 无法改 PR head，故以 `vpc` 重新开本 PR，并关闭 #6。

## Test plan

- [x] `npm test`（119 passed）
- [x] `tsc --noEmit`
- [ ] 设置 `QODER_VPC_INSTANCE=sungrow-of-enterprise`，删除本机 PAT env 后**完全重启 OMP**，验证 VPC `qoder-cn` 冷启动可聊天
- [ ] stale `auth.json` + 新 DB access → 走 `/userinfo` 而非混用旧身份