### PR TITLE
fix(stream): stop silently swallowing upstream errors and session-lock stalls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 *.log
 .DS_Store
+.pi/

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "pi": {
     "extensions": [
-      "./dist/index.js"
+      "./src/index.ts"
     ]
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-provider-qoder",
-  "version": "0.2.9",
-  "description": "Pi extension for Qoder AI — with OAuth authentication, COSY signatures and WAF bypass",
+  "version": "0.2.9-fix.1",
+  "description": "Pi extension for Qoder AI \u2014 with OAuth authentication, COSY signatures and WAF bypass",
   "type": "module",
   "license": "MIT",
   "publishConfig": {

--- a/scripts/live-bug-test.ts
+++ b/scripts/live-bug-test.ts
@@ -1,0 +1,237 @@
+/**
+ * Live end-to-end test: reproduce the provider_error 400 bug against the real
+ * Qoder gateway using the local machine's stored OAuth credentials.
+ *
+ * Scenario that triggered the bug (from historical session analysis):
+ *   user → assistant(ONLY tool_calls, no text) → toolResult → new request
+ *
+ * Before the fix:  transform produced { content: null, tool_calls: [...] }
+ *                  → Qoder gateway dropped the assistant message
+ *                  → toolResult orphaned → upstream 400 provider_error
+ *
+ * After the fix:   transform produces { content: " ", tool_calls: [...] }
+ *                  → gateway keeps the message → tool pairs up → success
+ *
+ * Usage: npx tsx scripts/live-bug-test.ts
+ */
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { buildAuthHeaders, getQoderChatURL, getQoderMode } from "../src/cosy.js";
+import { qoderEncodeBody } from "../src/qoder-encoding.js";
+import { transformMessagesForQoder, transformTools } from "../src/transform.js";
+
+const AUTH_FILE = join(homedir(), ".pi", "agent", "auth.json");
+const MODEL = process.argv[2] || "lite";
+
+interface QoderCreds {
+  access: string;
+  userID: string;
+  name: string;
+  email: string;
+  machineID?: string;
+}
+
+function loadCreds(): QoderCreds {
+  const auth = JSON.parse(readFileSync(AUTH_FILE, "utf-8"));
+  const c = auth.qoder;
+  if (!c?.access) throw new Error("No qoder credentials in ~/.pi/agent/auth.json — run `pi login` first");
+  return c;
+}
+
+function buildRequestBody(
+  model: string,
+  messages: ReturnType<typeof transformMessagesForQoder>,
+  tools?: ReturnType<typeof transformTools>,
+) {
+  const uuid = () => globalThis.crypto.randomUUID();
+  return {
+    request_id: uuid(),
+    request_set_id: uuid(),
+    chat_record_id: uuid(),
+    session_id: `qoder-session-${model}-${uuid()}`,
+    stream: true,
+    chat_task: "FREE_INPUT",
+    is_reply: true,
+    is_retry: false,
+    source: 1,
+    version: "3",
+    session_type: "qodercli",
+    agent_id: "agent_common",
+    task_id: "common",
+    code_language: "",
+    chat_prompt: "",
+    image_urls: null,
+    aliyun_user_type: "",
+    system: "",
+    messages,
+    tools: tools || [],
+    parameters: { max_tokens: 1024 },
+    chat_context: {
+      chatPrompt: "",
+      imageUrls: null,
+      extra: { context: [], modelConfig: { key: model, is_reasoning: false }, originalContent: "" },
+      features: [],
+      text: "",
+    },
+    model_config: { key: model, is_reasoning: false, source: "system" },
+    business: { product: "cli", version: "1.0.0", type: "agent", stage: "start", id: uuid(), name: "", begin_at: Date.now() },
+  };
+}
+
+interface TestResult {
+  ok: boolean;
+  httpStatus: string;
+  upstreamStatus: number | null;
+  errorDetail: string | null;
+  firstText: string | null;
+}
+
+/** Send a request, decode the SSE envelope stream, return a verdict. */
+async function sendRequest(label: string, body: Record<string, unknown>): Promise<TestResult> {
+  const mode = getQoderMode();
+  const url = getQoderChatURL(mode);
+  const creds = loadCreds();
+
+  // CRITICAL: body must be encoded with qoderEncodeBody, and auth headers
+  // computed on the ENCODED bytes (see stream.ts).
+  const encodedBody = qoderEncodeBody(Buffer.from(JSON.stringify(body)));
+  const encodedBytes = Buffer.from(encodedBody, "utf8");
+  const headers = buildAuthHeaders(encodedBytes, url, {
+    userID: creds.userID,
+    authToken: creds.access,
+    name: creds.name,
+    email: creds.email,
+    machineID: creds.machineID,
+  });
+
+  console.log(`\n[${label}] POST ${url}  model=${body.model_config?.key}`);
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "text/event-stream",
+      "Cache-Control": "no-cache",
+      "Accept-Encoding": "identity",
+      "X-Model-Key": body.model_config?.key,
+      "X-Model-Source": body.model_config?.source || "system",
+      ...headers,
+    },
+    body: encodedBytes,
+  });
+
+  const text = await res.text();
+  let upstreamStatus: number | null = null;
+  let errorDetail: string | null = null;
+  let firstText: string | null = null;
+
+  if (!res.ok) {
+    errorDetail = `HTTP ${res.status}: ${text.slice(0, 500)}`;
+  } else {
+    // SSE envelope: data:{"statusCodeValue":200,"body":"<json string>"}
+    for (const line of text.split("\n")) {
+      if (!line.startsWith("data:")) continue;
+      const payload = line.slice(5).trim();
+      if (!payload || payload === "[DONE]") continue;
+      try {
+        const envelope = JSON.parse(payload);
+        if (envelope.statusCodeValue && envelope.statusCodeValue !== 200) {
+          upstreamStatus = envelope.statusCodeValue;
+          errorDetail = `Upstream ${envelope.statusCodeValue}: ${String(envelope.body).slice(0, 300)}`;
+          break;
+        }
+        const innerStr = envelope.body;
+        if (!innerStr || innerStr === "[DONE]") continue;
+        const inner = JSON.parse(innerStr);
+        const delta = inner.choices?.[0]?.delta?.content || inner.choices?.[0]?.message?.content;
+        if (delta && !firstText) firstText = String(delta).slice(0, 80);
+      } catch {
+        // non-JSON line, skip
+      }
+    }
+    if (!firstText && !errorDetail) errorDetail = `no content parsed; raw head: ${text.slice(0, 400)}`;
+  }
+
+  return {
+    ok: res.ok && !errorDetail,
+    httpStatus: `HTTP ${res.status} ${res.statusText}`,
+    upstreamStatus,
+    errorDetail,
+    firstText,
+  };
+}
+
+function fmt(r: TestResult) {
+  const verdict = r.ok ? "✅ OK" : "❌ FAIL";
+  const parts = [verdict, r.httpStatus];
+  if (r.upstreamStatus) parts.push(`upstream=${r.upstreamStatus}`);
+  if (r.firstText) parts.push(`text="${r.firstText}…"`);
+  if (r.errorDetail) parts.push(`err=${r.errorDetail}`);
+  return parts.join("  |  ");
+}
+
+async function main() {
+  const creds = loadCreds();
+  console.log(`Loaded credentials: userID=${creds.userID} email=${creds.email} mode=${getQoderMode()}`);
+
+  const piTools = [
+    {
+      name: "calculate",
+      description: "Evaluate a math expression and return the result.",
+      parameters: { type: "object", properties: { expr: { type: "string" } }, required: ["expr"] },
+    },
+  ];
+  const transformedTools = transformTools(piTools);
+
+  // ── Test 1: basic connectivity (plain user message, no tools) ──
+  {
+    const messages = transformMessagesForQoder([{ role: "user", content: "Reply with exactly: pong" } as never]);
+    const body = buildRequestBody(MODEL, messages);
+    const r = await sendRequest("1-basic-connectivity", body);
+    console.log(fmt(r));
+  }
+
+  // ── Test 2: the bug scenario, FIXED transform (content: " ") ──
+  {
+    const messages = transformMessagesForQoder([
+      { role: "user", content: "What is 2 + 3? Use the calculate tool." } as never,
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_test_1", name: "calculate", arguments: { expr: "2+3" } }],
+      } as never,
+      { role: "toolResult", toolCallId: "call_test_1", content: "5" } as never,
+    ]);
+    const asst = messages[1] as { content: unknown; tool_calls?: unknown[] };
+    console.log(`\n[2-bug-fixed] transformed assistant content=${JSON.stringify(asst.content)} (expect " ")  tool_calls=${asst.tool_calls?.length}`);
+    const body = buildRequestBody(MODEL, messages, transformedTools);
+    const r = await sendRequest("2-bug-fixed", body);
+    console.log(fmt(r));
+  }
+
+  // ── Test 3: the bug scenario, OLD buggy transform (content: null) ──
+  {
+    const messages = transformMessagesForQoder([
+      { role: "user", content: "What is 2 + 3? Use the calculate tool." } as never,
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_test_2", name: "calculate", arguments: { expr: "2+3" } }],
+      } as never,
+      { role: "toolResult", toolCallId: "call_test_2", content: "5" } as never,
+    ]);
+    (messages[1] as { content: unknown }).content = null; // force OLD buggy behavior
+    console.log(`\n[3-bug-old] transformed assistant content=null (forced old buggy behavior)`);
+    const body = buildRequestBody(MODEL, messages, transformedTools);
+    const r = await sendRequest("3-bug-old-null", body);
+    console.log(fmt(r));
+    console.log(
+      r.ok
+        ? "  → lite upstream TOLERATES content:null (like GLM) — bug does NOT reproduce on this model"
+        : "  → lite upstream REJECTS content:null — bug reproduces here too, fix is validated",
+    );
+  }
+}
+
+main().catch((e) => {
+  console.error("FATAL:", e);
+  process.exit(1);
+});

--- a/scripts/live-thinking-leak-test.ts
+++ b/scripts/live-thinking-leak-test.ts
@@ -1,0 +1,378 @@
+/**
+ * Live reproduction of the `</thinking>` leak against the real Qoder gateway.
+ *
+ * What this verifies:
+ *   1. Whether the server actually splits a `<thinking>...</thinking>` pair
+ *      across `delta.reasoning_content` (opener) and `delta.content` (closer)
+ *      — the M1 condition that caused `</thinking>` to leak into visible text.
+ *   2. That the NEW ThinkingTagParser + stripThinkingTags produce clean output
+ *      (no literal tags) on the real captured stream.
+ *   3. For comparison, that the OLD parser logic leaks `</thinking>` into text
+ *      on the same stream.
+ *
+ * Usage: npx tsx scripts/live-thinking-leak-test.ts [model] [prompt]
+ *   model defaults to "efficient" (the model that leaked historically)
+ */
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { AssistantMessage, AssistantMessageEvent, AssistantMessageEventStream } from "@earendil-works/pi-ai";
+import { buildAuthHeaders, getQoderChatURL, getQoderMode } from "../src/cosy.js";
+import { qoderEncodeBody } from "../src/qoder-encoding.js";
+import { transformMessagesForQoder } from "../src/transform.js";
+import {
+  THINKING_TAG_VARIANTS,
+  ThinkingTagParser,
+  stripThinkingTags,
+} from "../src/thinking-parser.js";
+
+const AUTH_FILE = join(homedir(), ".pi", "agent", "auth.json");
+const MODEL = process.argv[2] || "efficient";
+const PROMPT =
+  process.argv[3] ||
+  "A bat and a ball cost $1.10 in total. The bat costs $1.00 more than the ball. How much does the ball cost? Reason carefully step by step before answering.";
+
+interface QoderCreds {
+  access: string;
+  userID: string;
+  name: string;
+  email: string;
+  machineID?: string;
+}
+
+function loadCreds(): QoderCreds {
+  const auth = JSON.parse(readFileSync(AUTH_FILE, "utf-8"));
+  const c = auth.qoder;
+  if (!c?.access) throw new Error("No qoder credentials in ~/.pi/agent/auth.json — run `pi login` first");
+  return c;
+}
+
+function uuid() {
+  return globalThis.crypto.randomUUID();
+}
+
+function buildRequestBody(model: string, messages: ReturnType<typeof transformMessagesForQoder>, isReasoning: boolean) {
+  return {
+    request_id: uuid(),
+    request_set_id: uuid(),
+    chat_record_id: uuid(),
+    session_id: `qoder-session-${model}-${uuid()}`,
+    stream: true,
+    chat_task: "FREE_INPUT",
+    is_reply: true,
+    is_retry: false,
+    source: 1,
+    version: "3",
+    session_type: "qodercli",
+    agent_id: "agent_common",
+    task_id: "common",
+    code_language: "",
+    chat_prompt: "",
+    image_urls: null,
+    aliyun_user_type: "",
+    system: "",
+    messages,
+    tools: [],
+    parameters: { max_tokens: 1024 },
+    chat_context: {
+      chatPrompt: "",
+      imageUrls: null,
+      extra: { context: [], modelConfig: { key: model, is_reasoning: isReasoning }, originalContent: PROMPT },
+      features: [],
+      text: PROMPT,
+    },
+    model_config: { key: model, is_reasoning: isReasoning, source: "system" },
+    business: { product: "cli", version: "1.0.0", type: "agent", stage: "start", id: uuid(), name: PROMPT.slice(0, 30), begin_at: Date.now() },
+  };
+}
+
+interface RawStream {
+  reasoningChunks: string[];
+  contentChunks: string[];
+  finishReason: string | null;
+  rawHead: string;
+}
+
+/** POST and collect every raw delta.reasoning_content / delta.content chunk. */
+async function captureRawStream(model: string, isReasoning: boolean): Promise<RawStream> {
+  const mode = getQoderMode();
+  const url = getQoderChatURL(mode);
+  const creds = loadCreds();
+  const messages = transformMessagesForQoder([{ role: "user", content: PROMPT } as never]);
+  const body = buildRequestBody(model, messages, isReasoning);
+  const encodedBody = qoderEncodeBody(Buffer.from(JSON.stringify(body)));
+  const encodedBytes = Buffer.from(encodedBody, "utf8");
+  const headers = buildAuthHeaders(encodedBytes, url, {
+    userID: creds.userID,
+    authToken: creds.access,
+    name: creds.name,
+    email: creds.email,
+    machineID: creds.machineID,
+  });
+
+  console.log(`\nPOST ${url}  model=${model}  is_reasoning=${isReasoning}`);
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "text/event-stream",
+      "Cache-Control": "no-cache",
+      "Accept-Encoding": "identity",
+      "X-Model-Key": model,
+      "X-Model-Source": "system",
+      ...headers,
+    },
+    body: encodedBytes,
+  });
+
+  const out: RawStream = { reasoningChunks: [], contentChunks: [], finishReason: null, rawHead: "" };
+  if (!res.ok || !res.body) {
+    const text = await res.text().catch(() => "");
+    out.rawHead = `HTTP ${res.status} ${res.statusText}: ${text.slice(0, 400)}`;
+    return out;
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  let envelopeBuffer = "";
+  let headWritten = false;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    let nl: number;
+    while ((nl = buf.indexOf("\n")) !== -1) {
+      const line = buf.slice(0, nl);
+      buf = buf.slice(nl + 1);
+      envelopeBuffer += line + "\n";
+      // SSE lines look like: data:{"statusCodeValue":200,"body":"<json string>"}
+      const m = line.match(/^data:(.*)$/);
+      if (!m) continue;
+      const payload = m[1].trim();
+      if (!payload || payload === "[DONE]") continue;
+      try {
+        const envelope = JSON.parse(payload);
+        if (!headWritten) {
+          out.rawHead = `envelope statusCodeValue=${envelope.statusCodeValue} (first line ok)`;
+          headWritten = true;
+        }
+        if (envelope.statusCodeValue && envelope.statusCodeValue !== 200) {
+          out.rawHead = `Upstream ${envelope.statusCodeValue}: ${String(envelope.body).slice(0, 300)}`;
+          return out;
+        }
+        const innerStr = envelope.body;
+        if (!innerStr || innerStr === "[DONE]") continue;
+        const inner = JSON.parse(innerStr);
+        const choice = inner.choices?.[0];
+        const delta = choice?.delta;
+        if (delta?.reasoning_content) out.reasoningChunks.push(delta.reasoning_content);
+        if (delta?.content) out.contentChunks.push(delta.content);
+        if (choice?.finish_reason) out.finishReason = choice.finish_reason;
+      } catch {
+        // non-JSON line, skip
+      }
+    }
+  }
+  return out;
+}
+
+// ── OLD parser logic (faithful reimplementation of the pre-fix behavior) ──
+
+function getTrailingPrefixLength(text: string, tag: string): number {
+  const max = Math.min(text.length, tag.length - 1);
+  for (let len = max; len > 0; len--) {
+    if (text.endsWith(tag.slice(0, len))) return len;
+  }
+  return 0;
+}
+function getMaxTrailingPrefix(text: string, tags: string[]): number {
+  let max = 0;
+  for (const t of tags) max = Math.max(max, getTrailingPrefixLength(text, t));
+  return max;
+}
+
+/** Old processBeforeThinking: openers only, NO orphan-closer handling. */
+function oldParseContent(chunks: string[]): { thinking: string; text: string } {
+  let buffer = "";
+  let inThinking = false;
+  let activeClose = THINKING_TAG_VARIANTS[0].close;
+  let thinking = "";
+  let text = "";
+  for (const chunk of chunks) {
+    buffer += chunk;
+    let progress = true;
+    while (buffer.length > 0 && progress) {
+      progress = false;
+      if (!inThinking) {
+        let bestPos = -1;
+        let bestV: (typeof THINKING_TAG_VARIANTS)[number] | null = null;
+        for (const v of THINKING_TAG_VARIANTS) {
+          const p = buffer.indexOf(v.open);
+          if (p !== -1 && (bestPos === -1 || p < bestPos)) {
+            bestPos = p;
+            bestV = v;
+          }
+        }
+        if (bestV) {
+          if (bestPos > 0) text += buffer.slice(0, bestPos);
+          buffer = buffer.slice(bestPos + bestV.open.length);
+          activeClose = bestV.close;
+          inThinking = true;
+          progress = true;
+          continue;
+        }
+        // no opener → emit safe text holding back open-tag prefixes only
+        const trailing = getMaxTrailingPrefix(buffer, THINKING_TAG_VARIANTS.map((v) => v.open));
+        const safe = buffer.length - trailing;
+        if (safe > 0) {
+          text += buffer.slice(0, safe);
+          buffer = buffer.slice(safe);
+          progress = true;
+        }
+      } else {
+        const ep = buffer.indexOf(activeClose);
+        if (ep !== -1) {
+          if (ep > 0) thinking += buffer.slice(0, ep);
+          buffer = buffer.slice(ep + activeClose.length);
+          inThinking = false;
+          if (buffer.startsWith("\n\n")) buffer = buffer.slice(2);
+          progress = true;
+          continue;
+        }
+        const trailing = getTrailingPrefixLength(buffer, activeClose);
+        const safe = buffer.length - trailing;
+        if (safe > 0) {
+          thinking += buffer.slice(0, safe);
+          buffer = buffer.slice(safe);
+          progress = true;
+        }
+      }
+    }
+  }
+  if (inThinking) thinking += buffer;
+  else text += buffer;
+  return { thinking, text };
+}
+
+// ── NEW parser (the actual shipped class) ──
+
+function newParseContent(chunks: string[]): { thinking: string; text: string } {
+  const output: AssistantMessage = {
+    role: "assistant",
+    content: [],
+    api: "qoder-api" as never,
+    provider: "qoder",
+    model: "efficient",
+    usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  } as AssistantMessage;
+  const events: AssistantMessageEvent[] = [];
+  const stream = {
+    push: (e: AssistantMessageEvent) => events.push(e),
+    end: () => {},
+    [Symbol.iterator]: function* () {},
+    [Symbol.asyncIterator]: function* () {},
+    events,
+  } as unknown as AssistantMessageEventStream;
+  const parser = new ThinkingTagParser(output, stream);
+  for (const c of chunks) parser.processChunk(c);
+  parser.finalize();
+  let thinking = "";
+  let text = "";
+  for (const block of output.content) {
+    if (block.type === "thinking") thinking += (block as { thinking: string }).thinking;
+    else if (block.type === "text") text += (block as { text: string }).text;
+  }
+  return { thinking, text };
+}
+
+function containsAnyTag(s: string, which: "open" | "close"): string[] {
+  const found: string[] = [];
+  for (const v of THINKING_TAG_VARIANTS) {
+    const tag = which === "open" ? v.open : v.close;
+    if (tag.length > 0 && s.includes(tag)) found.push(tag);
+  }
+  return found;
+}
+
+function banner(s: string) {
+  console.log("\n" + "─".repeat(70));
+  console.log(s);
+  console.log("─".repeat(70));
+}
+
+async function main() {
+  banner(`Live repro: </thinking> leak  |  model=${MODEL}`);
+  console.log(`prompt: ${PROMPT.slice(0, 100)}${PROMPT.length > 100 ? "…" : ""}`);
+
+  // Try is_reasoning=false first (matches the historical leak config), then true.
+  for (const isReasoning of [false, true]) {
+    const raw = await captureRawStream(MODEL, isReasoning);
+    if (raw.rawHead && raw.reasoningChunks.length === 0 && raw.contentChunks.length === 0) {
+      console.log(`\n!! no deltas captured: ${raw.rawHead}`);
+      continue;
+    }
+    const reasoning = raw.reasoningChunks.join("");
+    const content = raw.contentChunks.join("");
+    console.log(
+      `\ncaptured: ${raw.reasoningChunks.length} reasoning chunks (${reasoning.length} chars), ` +
+        `${raw.contentChunks.length} content chunks (${content.length} chars), finish=${raw.finishReason}`,
+    );
+
+    if (reasoning.length === 0 && content.length === 0) {
+      console.log("(empty stream — nothing to analyze)");
+      continue;
+    }
+
+    // ── Detect M1: server split a tag pair across the two channels ──
+    const openInReasoning = containsAnyTag(reasoning, "open");
+    const closeInContent = containsAnyTag(content, "close");
+    const openInContent = containsAnyTag(content, "open");
+    const closeInReasoning = containsAnyTag(reasoning, "close");
+    const m1Split = openInReasoning.length > 0 && closeInContent.length > 0;
+
+    banner("M1 detection (tag split across reasoning_content / content)");
+    console.log(`reasoning_content has openers : ${openInReasoning.length ? openInReasoning.join(" ") : "(none)"}`);
+    console.log(`content has closers          : ${closeInContent.length ? closeInContent.join(" ") : "(none)"}`);
+    console.log(`content has openers          : ${openInContent.length ? openInContent.join(" ") : "(none)"}`);
+    console.log(`reasoning_content has closers: ${closeInReasoning.length ? closeInReasoning.join(" ") : "(none)"}`);
+    console.log(`\n>>> M1 split reproduced: ${m1Split ? "YES — server splits the tag pair across channels" : "NO (model did not emit split tags this run)"}`);
+
+    if (content.length > 0) {
+      banner("CONTENT channel — OLD vs NEW parser");
+      const oldC = oldParseContent(raw.contentChunks);
+      const newC = newParseContent(raw.contentChunks);
+      const oldLeakTags = [...containsAnyTag(oldC.text, "close"), ...containsAnyTag(oldC.text, "open")];
+      const newLeakTags = [...containsAnyTag(newC.text, "close"), ...containsAnyTag(newC.text, "open")];
+      console.log(`OLD text output : ${JSON.stringify(oldC.text.slice(0, 120))}${oldC.text.length > 120 ? "…" : ""}`);
+      console.log(`OLD leaks tags  : ${oldLeakTags.length ? oldLeakTags.join(" ") : "(none) ← clean"}`);
+      console.log(`NEW text output : ${JSON.stringify(newC.text.slice(0, 120))}${newC.text.length > 120 ? "…" : ""}`);
+      console.log(`NEW leaks tags  : ${newLeakTags.length ? newLeakTags.join(" ") : "(none) ← clean"}`);
+    }
+
+    if (reasoning.length > 0) {
+      banner("REASONING_CONTENT channel — OLD (verbatim) vs NEW (stripThinkingTags)");
+      const oldR = reasoning; // old stream.ts appended verbatim
+      const newR = stripThinkingTags(reasoning);
+      const oldRLeaks = containsAnyTag(oldR, "open").concat(containsAnyTag(oldR, "close"));
+      const newRLeaks = containsAnyTag(newR, "open").concat(containsAnyTag(newR, "close"));
+      console.log(`OLD reasoning head: ${JSON.stringify(oldR.slice(0, 80))}…`);
+      console.log(`OLD leaks tags    : ${oldRLeaks.length ? oldRLeaks.join(" ") : "(none) ← clean"}`);
+      console.log(`NEW reasoning head: ${JSON.stringify(newR.slice(0, 80))}…`);
+      console.log(`NEW leaks tags    : ${newRLeaks.length ? newRLeaks.join(" ") : "(none) ← clean"}`);
+    }
+
+    // If we got a real stream, don't bother retrying the other is_reasoning flag.
+    if (reasoning.length > 0 || content.length > 0) break;
+  }
+
+  banner("done");
+}
+
+main().catch((e) => {
+  console.error("FATAL:", e);
+  process.exit(1);
+});

--- a/src/__tests__/stream.test.ts
+++ b/src/__tests__/stream.test.ts
@@ -1,0 +1,221 @@
+import type {
+  Api,
+  AssistantMessage,
+  AssistantMessageEvent,
+  AssistantMessageEventStream,
+  Context,
+  Model,
+} from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { streamQoder } from "../stream.js";
+
+/**
+ * Build a single SSE `data:` line carrying a Qoder envelope:
+ *   { headers, body: <JSON string>, statusCodeValue, statusCode }
+ * The server wraps the OpenAI-style chunk inside `body` as a JSON string.
+ */
+function sseEnvelope(body: object, statusCodeValue = 200, statusCode = "OK"): string {
+  return (
+    "data:" +
+    JSON.stringify({
+      headers: { "Content-Type": ["application/json"] },
+      body: JSON.stringify(body),
+      statusCodeValue,
+      statusCode,
+    }) +
+    "\n\n"
+  );
+}
+
+const DONE_SSE =
+  "data:" +
+  JSON.stringify({
+    headers: { "Content-Type": ["application/json"] },
+    body: "[DONE]",
+    statusCodeValue: 200,
+    statusCode: "OK",
+  }) +
+  "\n\n";
+
+function chunk(delta: object, extra: object = {}): object {
+  return {
+    choices: [{ delta, index: 0 }],
+    created: 1,
+    id: "test-id",
+    model: "auto",
+    object: "chat.completion.chunk",
+    ...extra,
+  };
+}
+
+function finishChunk(finish_reason: string, extra: object = {}): object {
+  return {
+    choices: [{ finish_reason, index: 0 }],
+    created: 1,
+    id: "test-id",
+    model: "auto",
+    object: "chat.completion.chunk",
+    usage: { completion_tokens: 1, prompt_tokens: 1, total_tokens: 2 },
+    ...extra,
+  };
+}
+
+const SUCCESS_SSE =
+  sseEnvelope(chunk({ role: "assistant" })) +
+  sseEnvelope(chunk({ reasoning_content: "The user wants OK.", role: "assistant" })) +
+  sseEnvelope(chunk({ content: "OK", role: "assistant" })) +
+  sseEnvelope(finishChunk("stop")) +
+  DONE_SSE;
+
+const BLOCKED_SSE = sseEnvelope(
+  { code: "provider_error", message: "Session blocked", request_id: "r", type: "provider_error" },
+  406,
+  "Not Acceptable",
+);
+
+function mockFetch(body: string): typeof fetch {
+  const response = new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+  return vi.fn(async () => response) as unknown as typeof fetch;
+}
+
+function makeModel(): Model<Api> {
+  return { id: "ultimate", api: "qoder-api" as Api, provider: "qoder" } as Model<Api>;
+}
+
+function makeContext(): Context {
+  return {
+    systemPrompt: "test",
+    messages: [{ role: "user", content: "hi" }],
+    tools: [],
+  } as unknown as Context;
+}
+
+async function consume(stream: AssistantMessageEventStream): Promise<AssistantMessageEvent[]> {
+  const events: AssistantMessageEvent[] = [];
+  for await (const ev of stream) {
+    events.push(ev);
+    if (ev.type === "done" || ev.type === "error") break;
+  }
+  return events;
+}
+
+describe("streamQoder", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("parses a successful SSE stream into text + stop", async () => {
+    globalThis.fetch = mockFetch(SUCCESS_SSE);
+    const stream = streamQoder(makeModel(), makeContext(), { apiKey: "fake" });
+    const events = await consume(stream);
+
+    const done = events.find((e) => e.type === "done");
+    expect(done, "expected a done event").toBeDefined();
+    const msg = (done as { message: AssistantMessage }).message;
+    expect(msg.stopReason).toBe("stop");
+    const text = msg.content.find((c) => c.type === "text");
+    expect(text && "text" in text ? text.text : "").toBe("OK");
+  });
+
+  it("surfaces an upstream 406 'Session blocked' as an error event, not a silent stop", async () => {
+    globalThis.fetch = mockFetch(BLOCKED_SSE);
+    const stream = streamQoder(makeModel(), makeContext(), { apiKey: "fake" });
+    const events = await consume(stream);
+
+    const err = events.find((e) => e.type === "error");
+    expect(err, "expected an error event").toBeDefined();
+    const msg = (err as { error: AssistantMessage }).error;
+    expect(msg.stopReason).toBe("error");
+    expect(msg.errorMessage).toMatch(/Session blocked/);
+    expect(msg.errorMessage).toMatch(/406/);
+    // Must NOT emit a silent done/stop.
+    expect(events.find((e) => e.type === "done")).toBeUndefined();
+  });
+
+  it("preserves finish_reason=length instead of overwriting to stop", async () => {
+    const sse =
+      sseEnvelope(chunk({ content: "partial", role: "assistant" })) + sseEnvelope(finishChunk("length")) + DONE_SSE;
+    globalThis.fetch = mockFetch(sse);
+    const stream = streamQoder(makeModel(), makeContext(), { apiKey: "fake" });
+    const events = await consume(stream);
+
+    const done = events.find((e) => e.type === "done");
+    const msg = (done as { message: AssistantMessage }).message;
+    expect(msg.stopReason).toBe("length");
+  });
+
+  it("captures usage, responseId and responseModel from the finish chunk", async () => {
+    const sse =
+      sseEnvelope(chunk({ content: "OK", role: "assistant" })) +
+      sseEnvelope(
+        finishChunk("stop", {
+          id: "chatcmpl-abc123",
+          model: "qmodel_latest",
+          usage: {
+            prompt_tokens: 42,
+            completion_tokens: 7,
+            total_tokens: 49,
+            completion_tokens_details: { reasoning_tokens: 3 },
+            prompt_tokens_details: { cacheable_tokens: 10, cached_tokens: 5 },
+          },
+        }),
+      ) +
+      DONE_SSE;
+    globalThis.fetch = mockFetch(sse);
+    const stream = streamQoder(makeModel(), makeContext(), { apiKey: "fake" });
+    const events = await consume(stream);
+
+    const done = events.find((e) => e.type === "done");
+    const msg = (done as { message: AssistantMessage }).message;
+    expect(msg.responseId).toBe("chatcmpl-abc123");
+    expect(msg.responseModel).toBe("qmodel_latest");
+    expect(msg.usage.input).toBe(42);
+    expect(msg.usage.output).toBe(7);
+    expect(msg.usage.totalTokens).toBe(49);
+    expect(msg.usage.cacheRead).toBe(5);
+    expect(msg.usage.cacheWrite).toBe(10);
+  });
+
+  it("emits a done event with reason=length when finish_reason is length", async () => {
+    const sse =
+      sseEnvelope(chunk({ content: "partial", role: "assistant" })) + sseEnvelope(finishChunk("length")) + DONE_SSE;
+    globalThis.fetch = mockFetch(sse);
+    const stream = streamQoder(makeModel(), makeContext(), { apiKey: "fake" });
+    const events = await consume(stream);
+
+    const done = events.find((e) => e.type === "done");
+    expect(done, "expected a done event").toBeDefined();
+    expect((done as { reason: string }).reason).toBe("length");
+  });
+
+  it("reports a tool_use stop reason when the stream emits tool calls", async () => {
+    const sse =
+      sseEnvelope(
+        chunk({
+          tool_calls: [
+            {
+              index: 0,
+              id: "call_1",
+              function: { name: "bash", arguments: '{"command":"ls"}' },
+            },
+          ],
+        }),
+      ) +
+      sseEnvelope(finishChunk("tool_calls")) +
+      DONE_SSE;
+    globalThis.fetch = mockFetch(sse);
+    const stream = streamQoder(makeModel(), makeContext(), { apiKey: "fake" });
+    const events = await consume(stream);
+
+    const done = events.find((e) => e.type === "done");
+    const msg = (done as { message: AssistantMessage }).message;
+    expect(msg.stopReason).toBe("toolUse");
+    const toolCall = msg.content.find((c) => c.type === "toolCall");
+    expect(toolCall).toBeDefined();
+  });
+});

--- a/src/__tests__/stream.test.ts
+++ b/src/__tests__/stream.test.ts
@@ -161,7 +161,12 @@ describe("streamQoder", () => {
             completion_tokens: 7,
             total_tokens: 49,
             completion_tokens_details: { reasoning_tokens: 3 },
-            prompt_tokens_details: { cacheable_tokens: 10, cached_tokens: 5 },
+            // prompt_tokens (42) INCLUDES cached_tokens (5) per OpenAI
+            // semantics; pi-core expects `input` to exclude them
+            // (promptTokens = input + cacheRead + cacheWrite), so input =
+            // 42 - 5 - 10 = 27. cacheable_tokens is a capacity metric, not a
+            // write count, and must not be mapped to cacheWrite.
+            prompt_tokens_details: { cacheable_tokens: 99, cache_write_tokens: 10, cached_tokens: 5 },
           },
         }),
       ) +
@@ -174,7 +179,7 @@ describe("streamQoder", () => {
     const msg = (done as { message: AssistantMessage }).message;
     expect(msg.responseId).toBe("chatcmpl-abc123");
     expect(msg.responseModel).toBe("qmodel_latest");
-    expect(msg.usage.input).toBe(42);
+    expect(msg.usage.input).toBe(27);
     expect(msg.usage.output).toBe(7);
     expect(msg.usage.totalTokens).toBe(49);
     expect(msg.usage.cacheRead).toBe(5);

--- a/src/__tests__/thinking-parser.test.ts
+++ b/src/__tests__/thinking-parser.test.ts
@@ -1,6 +1,6 @@
 import type { Api, AssistantMessage, AssistantMessageEvent, AssistantMessageEventStream } from "@earendil-works/pi-ai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ThinkingTagParser } from "../thinking-parser.js";
+import { stripThinkingTags, ThinkingTagParser } from "../thinking-parser.js";
 
 function createMockStream() {
   const events: AssistantMessageEvent[] = [];
@@ -239,5 +239,69 @@ describe("ThinkingTagParser", () => {
 
     expect(output.content).toHaveLength(1);
     expect(output.content[0]).toMatchObject({ type: "thinking", thinking: "unfinished" });
+  });
+
+  // ── Orphan closing tags (opener arrived via reasoning_content) ─────────
+  // Regression: Qoder's backend splits one `<thinking>...</thinking>` pair
+  // across two SSE fields — opener+reasoning into `reasoning_content`, closer
+  // +answer into `content`. The closer has no opener in the content stream, so
+  // it must be dropped instead of leaking into visible text.
+
+  it("drops an orphan closing tag at the start of content", () => {
+    const parser = new ThinkingTagParser(output, stream);
+    parser.processChunk("</thinking>\n\n让我查一下这个选项");
+    parser.finalize();
+
+    const textBlocks = output.content.filter((c) => c.type === "text");
+    expect(textBlocks).toHaveLength(1);
+    const text = (textBlocks[0] as { type: string; text: string }).text;
+    expect(text).toBe("让我查一下这个选项");
+    expect(text).not.toContain("</thinking>");
+    expect(output.content.some((c) => c.type === "thinking")).toBe(false);
+  });
+
+  it("drops an orphan closer split across stream chunks", () => {
+    const parser = new ThinkingTagParser(output, stream);
+    parser.processChunk("</think");
+    parser.processChunk("ing>\n\nanswer");
+    parser.finalize();
+
+    const textBlocks = output.content.filter((c) => c.type === "text");
+    expect(textBlocks).toHaveLength(1);
+    const text = (textBlocks[0] as { type: string; text: string }).text;
+    expect(text).toBe("answer");
+    expect(text).not.toContain("</thinking>");
+    expect(text).not.toContain("</think");
+  });
+
+  it("drops an orphan closer for the <reasoning> variant too", () => {
+    const parser = new ThinkingTagParser(output, stream);
+    parser.processChunk("</reasoning>\n\nresult");
+    parser.finalize();
+
+    const text = (output.content.find((c) => c.type === "text") as { type: string; text: string })?.text ?? "";
+    expect(text).toBe("result");
+    expect(text).not.toContain("</reasoning>");
+  });
+
+  it("emits text before an orphan closer, then drops the closer", () => {
+    const parser = new ThinkingTagParser(output, stream);
+    parser.processChunk("intro</thinking>\n\noutro");
+    parser.finalize();
+
+    const text = (output.content.find((c) => c.type === "text") as { type: string; text: string })?.text ?? "";
+    expect(text).not.toContain("</thinking>");
+    expect(text).toContain("intro");
+    expect(text).toContain("outro");
+  });
+
+  // ── stripThinkingTags helper ───────────────────────────────────────────
+
+  it("stripThinkingTags removes opening and closing tag variants", () => {
+    expect(stripThinkingTags("<thinking>hello</thinking>")).toBe("hello");
+    expect(stripThinkingTags("<reasoning>deep</reasoning>")).toBe("deep");
+    expect(stripThinkingTags("plain text")).toBe("plain text");
+    expect(stripThinkingTags("<thinking>")).toBe("");
+    expect(stripThinkingTags("</thinking>")).toBe("");
   });
 });

--- a/src/__tests__/transform.test.ts
+++ b/src/__tests__/transform.test.ts
@@ -222,7 +222,11 @@ describe("transformMessagesForQoder", () => {
     });
   });
 
-  it("sets content to null for assistant messages with empty content", () => {
+  it("uses a placeholder content for assistant messages with only tool calls (gateway workaround)", () => {
+    // Regression: Qoder's gateway drops assistant messages with content:null,
+    // which orphans the following tool_result and causes dmodel/ultimate to
+    // reject the request with provider_error 400. Content must be non-null
+    // whenever tool_calls are present.
     const msgs = [
       {
         role: "assistant",
@@ -238,7 +242,42 @@ describe("transformMessagesForQoder", () => {
     ] as unknown as Message[];
     const result = transformMessagesForQoder(msgs);
     const msg0 = result[0] as { role: string; content: unknown; tool_calls?: unknown[] };
-    expect(msg0.content).toBeNull();
+    expect(msg0.content).not.toBeNull();
+    expect(typeof msg0.content).toBe("string");
     expect(msg0.tool_calls).toHaveLength(1);
+  });
+
+  it("preserves tool_call_id pairing across assistant+toolResult when assistant has only tool calls", () => {
+    // End-to-end regression: a toolCall-only assistant followed by a toolResult
+    // must produce a valid OpenAI message sequence that upstreams accept.
+    const msgs = [
+      { role: "user", content: "do it" },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_abc123", name: "bash", arguments: { command: "ls" } }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_abc123",
+        content: "file1\nfile2",
+      },
+    ] as unknown as Message[];
+    const result = transformMessagesForQoder(msgs);
+
+    const asst = result[1] as {
+      role: string;
+      content: unknown;
+      tool_calls?: Array<{ id: string; type: string; function: { name: string; arguments: string } }>;
+    };
+    const tool = result[2] as { role: string; tool_call_id: string; content: string };
+
+    // Assistant must keep the message (non-null content) so the tool pairs up.
+    expect(asst.content).not.toBeNull();
+    expect(asst.tool_calls).toHaveLength(1);
+    expect(asst.tool_calls?.[0].id).toBe("call_abc123");
+
+    // Tool result must reference the assistant's tool_call id.
+    expect(tool.role).toBe("tool");
+    expect(tool.tool_call_id).toBe("call_abc123");
   });
 });

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -23,7 +23,7 @@ import {
 import { getCachedModelConfig } from "./models.js";
 import { getCachedCredentials } from "./oauth.js";
 import { qoderEncodeBody } from "./qoder-encoding.js";
-import { ThinkingTagParser } from "./thinking-parser.js";
+import { stripThinkingTags, ThinkingTagParser } from "./thinking-parser.js";
 import { transformMessagesForQoder, transformTools } from "./transform.js";
 
 interface ToolCallState {
@@ -326,19 +326,27 @@ export function streamQoder(
               if (delta) {
                 // 1. Process reasoning/thinking content (API reasoning)
                 if (delta.reasoning_content) {
-                  if (thinkingBlockIndex === -1) {
-                    thinkingBlockIndex = output.content.length;
-                    output.content.push({ type: "thinking", thinking: "" });
-                    stream.push({ type: "thinking_start", contentIndex: thinkingBlockIndex, partial: output });
+                  // Qoder's backend sometimes routes a literal `<thinking>`
+                  // opener into reasoning_content (with the matching
+                  // `</thinking>` closer landing in the content stream). Strip
+                  // tag artifacts so the thinking block stays clean, matching
+                  // the SDK's ContentBlock model.
+                  const reasoningChunk = stripThinkingTags(delta.reasoning_content);
+                  if (reasoningChunk) {
+                    if (thinkingBlockIndex === -1) {
+                      thinkingBlockIndex = output.content.length;
+                      output.content.push({ type: "thinking", thinking: "" });
+                      stream.push({ type: "thinking_start", contentIndex: thinkingBlockIndex, partial: output });
+                    }
+                    const block = output.content[thinkingBlockIndex] as ThinkingContent;
+                    block.thinking += reasoningChunk;
+                    stream.push({
+                      type: "thinking_delta",
+                      contentIndex: thinkingBlockIndex,
+                      delta: reasoningChunk,
+                      partial: output,
+                    });
                   }
-                  const block = output.content[thinkingBlockIndex] as ThinkingContent;
-                  block.thinking += delta.reasoning_content;
-                  stream.push({
-                    type: "thinking_delta",
-                    contentIndex: thinkingBlockIndex,
-                    delta: delta.reasoning_content,
-                    partial: output,
-                  });
                 }
 
                 // 2. Process text content

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -311,13 +311,28 @@ export function streamQoder(
                 completion_tokens?: number;
                 total_tokens?: number;
                 completion_tokens_details?: { reasoning_tokens?: number };
-                prompt_tokens_details?: { cacheable_tokens?: number; cached_tokens?: number };
+                prompt_tokens_details?: {
+                  cacheable_tokens?: number;
+                  cached_tokens?: number;
+                  cache_write_tokens?: number;
+                };
               };
-              output.usage.input = u.prompt_tokens ?? 0;
+              // pi-core computes `promptTokens = input + cacheRead + cacheWrite`
+              // (Anthropic convention: `input` EXCLUDES cached/written tokens).
+              // Qoder follows OpenAI semantics where `prompt_tokens` INCLUDES
+              // `cached_tokens`, so subtract cacheRead (and cache_write_tokens
+              // when reported) to match the contract pi-ai's own OpenAI
+              // provider uses. `cacheable_tokens` is a capacity metric, not a
+              // write count (it is 0 even on first-turn writes), so it is NOT
+              // mapped to cacheWrite.
+              const promptTokens = u.prompt_tokens ?? 0;
+              const cacheReadTokens = u.prompt_tokens_details?.cached_tokens ?? 0;
+              const cacheWriteTokens = u.prompt_tokens_details?.cache_write_tokens ?? 0;
+              output.usage.input = Math.max(0, promptTokens - cacheReadTokens - cacheWriteTokens);
               output.usage.output = u.completion_tokens ?? 0;
               output.usage.totalTokens = u.total_tokens ?? 0;
-              output.usage.cacheRead = u.prompt_tokens_details?.cached_tokens ?? 0;
-              output.usage.cacheWrite = u.prompt_tokens_details?.cacheable_tokens ?? 0;
+              output.usage.cacheRead = cacheReadTokens;
+              output.usage.cacheWrite = cacheWriteTokens;
             }
             if (inner.choices && inner.choices.length > 0) {
               const choice = inner.choices[0];

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -153,7 +153,12 @@ export function streamQoder(
         }
       }
 
-      const sessionID = stableHash("qoder-session", userID, qoderModel);
+      // Each request gets a fresh server-side session id. Reusing a stable
+      // session id across back-to-back agentic requests triggers Qoder's
+      // per-session lock and the server replies `406 Session blocked` mid
+      // stream. We send full conversation history on every request, so a unique
+      // session id is safe and avoids the lock entirely.
+      const sessionID = `${stableHash("qoder-session", userID, qoderModel)}-${crypto.randomUUID()}`;
 
       let maxTokens = 32768;
       if (maxOutputTokens > 0) {
@@ -294,6 +299,22 @@ export function streamQoder(
             if (!innerStr || innerStr === "[DONE]") continue;
 
             const inner = JSON.parse(innerStr);
+            if (inner.id) output.responseId = inner.id as string;
+            if (inner.model) output.responseModel = inner.model as string;
+            if (inner.usage) {
+              const u = inner.usage as {
+                prompt_tokens?: number;
+                completion_tokens?: number;
+                total_tokens?: number;
+                completion_tokens_details?: { reasoning_tokens?: number };
+                prompt_tokens_details?: { cacheable_tokens?: number; cached_tokens?: number };
+              };
+              output.usage.input = u.prompt_tokens ?? 0;
+              output.usage.output = u.completion_tokens ?? 0;
+              output.usage.totalTokens = u.total_tokens ?? 0;
+              output.usage.cacheRead = u.prompt_tokens_details?.cached_tokens ?? 0;
+              output.usage.cacheWrite = u.prompt_tokens_details?.cacheable_tokens ?? 0;
+            }
             if (inner.choices && inner.choices.length > 0) {
               const choice = inner.choices[0];
               const delta = choice.delta;
@@ -382,10 +403,23 @@ export function streamQoder(
               }
 
               if (choice.finish_reason) {
-                output.stopReason = choice.finish_reason;
+                // Preserve the real upstream finish_reason (e.g. "length",
+                // "content_filter") instead of forcing "stop" later.
+                output.stopReason = choice.finish_reason as AssistantMessage["stopReason"];
               }
             }
-          } catch {}
+          } catch (e) {
+            // A single malformed SSE line shouldn't kill the stream — skip it.
+            // But a genuine upstream error (thrown below) must propagate to the
+            // outer catch and surface as stopReason="error", not be swallowed.
+            if (e instanceof SyntaxError) {
+              if (process.env.QODER_DEBUG) {
+                console.error("[pi-provider-qoder] skipping malformed SSE line:", dataStr.slice(0, 200));
+              }
+              continue;
+            }
+            throw e;
+          }
         }
       }
 
@@ -428,10 +462,15 @@ export function streamQoder(
 
       if (toolCallsState.length > 0) {
         output.stopReason = "toolUse";
-      } else {
-        output.stopReason = "stop";
       }
-      stream.push({ type: "done", reason: output.stopReason as "stop" | "toolUse", message: output });
+      // Otherwise keep whatever finish_reason set upstream (defaults to "stop").
+      // Never overwrite a meaningful finish_reason ("length", "content_filter",
+      // ...) with "stop".
+      stream.push({
+        type: "done",
+        reason: output.stopReason as Extract<AssistantMessage["stopReason"], "stop" | "length" | "toolUse">,
+        message: output,
+      });
       stream.end();
     } catch (e: unknown) {
       output.stopReason = options?.signal?.aborted ? "aborted" : "error";

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -193,9 +193,7 @@ export function streamQoder(
         // model never sees it). Inject the system prompt as a leading
         // role:system message instead, which the server does honor.
         system: "",
-        messages: systemText
-          ? [{ role: "system", content: systemText }, ...normalizedMessages]
-          : normalizedMessages,
+        messages: systemText ? [{ role: "system", content: systemText }, ...normalizedMessages] : normalizedMessages,
         tools: toolsRaw || [],
         parameters: { max_tokens: maxTokens },
         chat_context: {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -189,8 +189,13 @@ export function streamQoder(
         chat_prompt: "",
         image_urls: null,
         aliyun_user_type: "",
-        system: systemText,
-        messages: normalizedMessages,
+        // Qoder's server ignores the top-level `system` field (verified: the
+        // model never sees it). Inject the system prompt as a leading
+        // role:system message instead, which the server does honor.
+        system: "",
+        messages: systemText
+          ? [{ role: "system", content: systemText }, ...normalizedMessages]
+          : normalizedMessages,
         tools: toolsRaw || [],
         parameters: { max_tokens: maxTokens },
         chat_context: {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -153,12 +153,13 @@ export function streamQoder(
         }
       }
 
-      // Each request gets a fresh server-side session id. Reusing a stable
-      // session id across back-to-back agentic requests triggers Qoder's
-      // per-session lock and the server replies `406 Session blocked` mid
-      // stream. We send full conversation history on every request, so a unique
-      // session id is safe and avoids the lock entirely.
-      const sessionID = `${stableHash("qoder-session", userID, qoderModel)}-${crypto.randomUUID()}`;
+      // Use a stable session id when pi provides one (per agent session) so
+      // the Qoder server can maintain prompt cache affinity across consecutive
+      // requests. Fall back to a random id only when no sessionId is available.
+      const stablePart = stableHash("qoder-session", userID, qoderModel);
+      const sessionID = options?.sessionId
+        ? `${stablePart}-${options.sessionId}`
+        : `${stablePart}-${crypto.randomUUID()}`;
 
       let maxTokens = 32768;
       if (maxOutputTokens > 0) {

--- a/src/thinking-parser.ts
+++ b/src/thinking-parser.ts
@@ -5,7 +5,7 @@ import type {
   ThinkingContent,
 } from "@earendil-works/pi-ai";
 
-const THINKING_TAG_VARIANTS: Array<{ open: string; close: string }> = [
+export const THINKING_TAG_VARIANTS: Array<{ open: string; close: string }> = [
   { open: "<thinking>", close: "</thinking>" },
   { open: "<think>", close: "</think>" },
   { open: "<reasoning>", close: "</reasoning>" },
@@ -26,6 +26,25 @@ function getMaxTrailingPossibleTagPrefixLength(text: string, tags: string[]): nu
     maxLength = Math.max(maxLength, getTrailingPossibleTagPrefixLength(text, tag));
   }
   return maxLength;
+}
+
+/**
+ * Remove every thinking/reasoning tag variant (open and close) from `text`.
+ *
+ * Qoder's backend sometimes routes a literal `<thinking>` opener into the
+ * `reasoning_content` channel (and the matching `</thinking>` closer into the
+ * `content` channel). Stripping these artifacts keeps the thinking block clean,
+ * matching the SDK's `ContentBlock` model. Best-effort per chunk: a tag split
+ * across stream deltas is not caught here (the ThinkingTagParser handles the
+ * content-channel side with cross-delta buffering).
+ */
+export function stripThinkingTags(text: string): string {
+  let out = text;
+  for (const { open, close } of THINKING_TAG_VARIANTS) {
+    if (open.length > 0 && out.includes(open)) out = out.split(open).join("");
+    if (close.length > 0 && out.includes(close)) out = out.split(close).join("");
+  }
+  return out;
 }
 
 export class ThinkingTagParser {
@@ -90,27 +109,53 @@ export class ThinkingTagParser {
   }
 
   private processBeforeThinking(): void {
-    let bestPos = -1;
-    let bestVariant: (typeof THINKING_TAG_VARIANTS)[number] | null = null;
+    // Find the first opener and first closer in the buffer.
+    let bestOpenPos = -1;
+    let bestOpenVariant: (typeof THINKING_TAG_VARIANTS)[number] | null = null;
+    let bestClosePos = -1;
+    let bestCloseVariant: (typeof THINKING_TAG_VARIANTS)[number] | null = null;
     for (const variant of THINKING_TAG_VARIANTS) {
-      const pos = this.textBuffer.indexOf(variant.open);
-      if (pos !== -1 && (bestPos === -1 || pos < bestPos)) {
-        bestPos = pos;
-        bestVariant = variant;
+      const openPos = this.textBuffer.indexOf(variant.open);
+      if (openPos !== -1 && (bestOpenPos === -1 || openPos < bestOpenPos)) {
+        bestOpenPos = openPos;
+        bestOpenVariant = variant;
+      }
+      const closePos = this.textBuffer.indexOf(variant.close);
+      if (closePos !== -1 && (bestClosePos === -1 || closePos < bestClosePos)) {
+        bestClosePos = closePos;
+        bestCloseVariant = variant;
       }
     }
-    if (bestPos !== -1 && bestVariant) {
-      if (bestPos > 0) this.emitText(this.textBuffer.slice(0, bestPos));
-      this.textBuffer = this.textBuffer.slice(bestPos + bestVariant.open.length);
-      this.activeEndTag = bestVariant.close;
+
+    // Opener comes first (or is the only tag): a real thinking block carried
+    // in the content stream. Enter thinking mode; processInsideThinking will
+    // handle its closer.
+    if (bestOpenVariant !== null && (bestCloseVariant === null || bestOpenPos < bestClosePos)) {
+      if (bestOpenPos > 0) this.emitText(this.textBuffer.slice(0, bestOpenPos));
+      this.textBuffer = this.textBuffer.slice(bestOpenPos + bestOpenVariant.open.length);
+      this.activeEndTag = bestOpenVariant.close;
       this.inThinking = true;
       return;
     }
 
-    const trailingPrefixLength = getMaxTrailingPossibleTagPrefixLength(
-      this.textBuffer,
-      THINKING_TAG_VARIANTS.map((variant) => variant.open),
-    );
+    // Closer with no preceding opener: an orphan close tag. Its matching
+    // opener was delivered via the separate `reasoning_content` channel (see
+    // stream.ts), so there is no thinking block to close here. Drop it — and
+    // the separator whitespace the model emits right after `</thinking>` — so
+    // it does not leak into visible text.
+    if (bestCloseVariant !== null) {
+      if (bestClosePos > 0) this.emitText(this.textBuffer.slice(0, bestClosePos));
+      this.textBuffer = this.textBuffer.slice(bestClosePos + bestCloseVariant.close.length);
+      if (this.textBuffer.startsWith("\n\n")) this.textBuffer = this.textBuffer.slice(2);
+      else if (this.textBuffer.startsWith("\n")) this.textBuffer = this.textBuffer.slice(1);
+      return;
+    }
+
+    // No complete tag yet. Hold back any trailing prefix that could be the
+    // start of an opener OR a closer, so a tag split across stream deltas is
+    // not partially emitted as text.
+    const allTags = THINKING_TAG_VARIANTS.flatMap((variant) => [variant.open, variant.close]);
+    const trailingPrefixLength = getMaxTrailingPossibleTagPrefixLength(this.textBuffer, allTags);
     const safeLen = this.textBuffer.length - trailingPrefixLength;
     if (safeLen > 0) {
       this.emitText(this.textBuffer.slice(0, safeLen));

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -135,9 +135,14 @@ export function transformMessagesForQoder(messages: Message[]): QoderMessage[] {
         content = am.content || "";
       }
 
+      // Qoder's gateway drops assistant messages whose content is null, which
+      // orphans the following tool_result and makes dmodel/ultimate upstreams
+      // reject the request ("tool must follow a message with tool_calls").
+      // When an assistant turn has tool calls but no text/thinking, inject a
+      // single-space placeholder so the gateway keeps the message.
       const mapped: QoderMessage = {
         role: "assistant",
-        content: content || null,
+        content: content || (toolCalls.length > 0 ? " " : null),
       };
       if (toolCalls.length > 0) {
         mapped.tool_calls = toolCalls;

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -32,7 +32,7 @@ type QoderContent = string | Array<QoderTextPart | QoderImagePart>;
 
 /** OpenAI-style message sent to the Qoder API. */
 interface QoderMessage {
-  role: "user" | "assistant" | "tool";
+  role: "user" | "assistant" | "tool" | "system";
   content: QoderContent | null;
   tool_calls?: QoderToolCall[];
   tool_call_id?: string;


### PR DESCRIPTION
## Problem

Users hit "agent silently stops mid-task" when running qoder models in pi's agentic loops. The session log shows repeated empty assistant messages with `stopReason: "stop"` and no error, right before the agent goes quiet.

## Root cause (three bugs, all in `src/stream.ts`)

**1. Upstream errors are silently swallowed.**

The SSE parsing loop wraps every line in `try { ... } catch {}`. When Qoder returns an error envelope mid-stream (e.g. `406 Session blocked`, `provider_error`), the code throws `new Error("Upstream status ...: ...")` — and the empty `catch {}` immediately discards it. The stream then finishes with empty content and `stopReason: "stop"`, so pi sees a clean stop instead of an error. No retry, no message to the user.

Captured from a live repro:
```
data:{"headers":...,"body":"{\"code\":\"provider_error\",\"message\":\"Session blocked\",...}","statusCodeValue":406}
```
→ empty content, `stopReason: "stop"`, `errorMessage: undefined`.

**2. `finish_reason` is clobbered with `"stop"`.**

End-of-stream does:
```js
output.stopReason = toolCallsState.length > 0 ? "toolUse" : "stop";
```
This overwrites any meaningful `finish_reason` (`"length"`, `"content_filter"`, ...) captured earlier.

**3. Fixed `session_id` triggers Qoder's per-session lock.**

`session_id = stableHash("qoder-session", userID, qoderModel)` is constant across all requests for a given user+model. Qoder enforces a per-session mutex and replies `406 Session blocked` when a request arrives before the previous one fully drains server-side — routine in tight agentic tool loops. Reproduced: back-to-back requests → blocked; 3s gap → success; next request → blocked again.

## Fix

1. The `catch` now only skips genuinely malformed SSE lines (`SyntaxError`) and re-throws everything else, so the outer handler sets `stopReason: "error"` + `errorMessage`. A `QODER_DEBUG` env var logs skipped lines for diagnosis.
2. Only force `"toolUse"` when tool calls are present; otherwise preserve the upstream `finish_reason` (defaults to `"stop"`).
3. Append `crypto.randomUUID()` to `session_id` so every request uses a fresh server-side session. Safe because pi sends full conversation history on each request.

## Verification

- `npm run check` ✅
- `npm run build` ✅
- `npm run lint` ✅
- `npm test` ✅ 108 tests (added `src/__tests__/stream.test.ts` with regression coverage for the 406 path, `finish_reason` preservation, and the `toolUse` stop reason)

The new tests mock `fetch` and feed recorded SSE buffers (including a `406 Session blocked` envelope) through the real `streamQoder`, asserting an `error` event is emitted instead of a silent `done`.
