### PR TITLE
fix: pi.extensions path should point to dist/index.js instead of src/index.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "pi": {
     "extensions": [
-      "./src/index.ts"
+      "./dist/index.js"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
The `files` field in `package.json` only includes `dist` and `README.md`, so `src/index.ts` is not available in the published npm package.

This was introduced in commit 1b110a6291b11d8ad82cff34332ce397a8089f1d ("fix index") which changed the path from the correct `./dist/index.js` to `./src/index.ts`.