### PR TITLE
fix: emit a tool call that arrives with no arguments

### DIFF
--- a/src/__tests__/stream.test.ts
+++ b/src/__tests__/stream.test.ts
@@ -5,6 +5,7 @@ import type {
   AssistantMessageEventStream,
   Context,
   Model,
+  ToolCall,
 } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { streamQoder } from "../stream.js";
@@ -222,5 +223,71 @@ describe("streamQoder", () => {
     expect(msg.stopReason).toBe("toolUse");
     const toolCall = msg.content.find((c) => c.type === "toolCall");
     expect(toolCall).toBeDefined();
+  });
+
+  it("emits a tool call that arrives with no arguments", async () => {
+    // A no-argument tool, or a model that sends id+name and stops. The block
+    // used to be created only inside `if (tc.function?.arguments)`, so this
+    // produced a toolCallsState entry and NO content block — and the finalizer
+    // then set stopReason "toolUse" on a message with no tool call in it. pi's
+    // agent loop had nothing to execute and the turn ended silently, mid-task.
+    const sse =
+      sseEnvelope(
+        chunk({
+          tool_calls: [{ index: 0, id: "call_1", function: { name: "advisor", arguments: "" } }],
+        }),
+      ) +
+      sseEnvelope(finishChunk("tool_calls")) +
+      DONE_SSE;
+    globalThis.fetch = mockFetch(sse);
+    const stream = streamQoder(makeModel(), makeContext(), { apiKey: "fake" });
+    const events = await consume(stream);
+
+    const done = events.find((e) => e.type === "done");
+    const msg = (done as { message: AssistantMessage }).message;
+    const toolCall = msg.content.find((c) => c.type === "toolCall") as ToolCall | undefined;
+    expect(toolCall, "a named tool call must reach the message even with no arguments").toBeDefined();
+    expect(toolCall?.name).toBe("advisor");
+    expect(toolCall?.id).toBe("call_1");
+    expect(toolCall?.arguments).toEqual({});
+    expect(msg.stopReason).toBe("toolUse");
+  });
+
+  it("picks up an id and name that arrive after the block is open", async () => {
+    // Streamed the other way round: arguments first, identity later.
+    const sse =
+      sseEnvelope(chunk({ tool_calls: [{ index: 0, function: { name: "bash", arguments: '{"comm' } }] })) +
+      sseEnvelope(chunk({ tool_calls: [{ index: 0, id: "call_9", function: { arguments: 'and":"ls"}' } }] })) +
+      sseEnvelope(finishChunk("tool_calls")) +
+      DONE_SSE;
+    globalThis.fetch = mockFetch(sse);
+    const stream = streamQoder(makeModel(), makeContext(), { apiKey: "fake" });
+    const events = await consume(stream);
+
+    const done = events.find((e) => e.type === "done");
+    const msg = (done as { message: AssistantMessage }).message;
+    const toolCall = msg.content.find((c) => c.type === "toolCall") as ToolCall | undefined;
+    expect(toolCall?.id).toBe("call_9");
+    expect(toolCall?.name).toBe("bash");
+    expect(toolCall?.arguments).toEqual({ command: "ls" });
+  });
+
+  it("does not claim toolUse when no tool call reached the message", async () => {
+    // A malformed stream: a tool_calls delta with neither id nor name. Better a
+    // clean "stop" than a message that says toolUse and carries nothing, which
+    // the agent loop cannot act on and cannot report.
+    const sse =
+      sseEnvelope(chunk({ content: "thinking about it", role: "assistant" })) +
+      sseEnvelope(chunk({ tool_calls: [{ index: 0, function: {} }] })) +
+      sseEnvelope(finishChunk("stop")) +
+      DONE_SSE;
+    globalThis.fetch = mockFetch(sse);
+    const stream = streamQoder(makeModel(), makeContext(), { apiKey: "fake" });
+    const events = await consume(stream);
+
+    const done = events.find((e) => e.type === "done");
+    const msg = (done as { message: AssistantMessage }).message;
+    expect(msg.content.find((c) => c.type === "toolCall")).toBeUndefined();
+    expect(msg.stopReason).toBe("stop");
   });
 });

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -407,17 +407,39 @@ export function streamQoder(
                     const state = toolCallsState[idx];
                     if (tc.id) state.id = tc.id;
                     if (tc.function?.name) state.name = tc.function.name;
+
+                    // Open the block as soon as the call is IDENTIFIABLE, not
+                    // when its first argument byte arrives. A call whose
+                    // arguments are absent or an empty string — a no-argument
+                    // tool, or a model that sends id+name and then stops — used
+                    // to create a toolCallsState entry and no content block, so
+                    // the finalizer below saw a non-empty state array, set
+                    // stopReason "toolUse", and handed back a message with no
+                    // tool call in it. The agent loop then had nothing to run
+                    // and the turn simply ended, mid-task and without an error.
+                    if (state.emittedStart === undefined && (state.id || state.name)) {
+                      state.emittedStart = true;
+                      state.contentIndex = output.content.length;
+                      output.content.push({
+                        type: "toolCall",
+                        id: state.id,
+                        name: state.name,
+                        arguments: {},
+                      } satisfies ToolCall);
+                      stream.push({ type: "toolcall_start", contentIndex: state.contentIndex, partial: output });
+                    }
+
+                    // id and name can arrive after the block is open; keep it
+                    // in step, since the finalizer only rewrites `arguments`.
+                    if (state.emittedStart) {
+                      const block = output.content[state.contentIndex] as ToolCall;
+                      block.id = state.id;
+                      block.name = state.name;
+                    }
+
                     if (tc.function?.arguments) {
                       const argDelta = tc.function.arguments;
                       state.arguments += argDelta;
-
-                      if (state.emittedStart === undefined) {
-                        state.emittedStart = true;
-                        state.contentIndex = output.content.length;
-                        const block: ToolCall = { type: "toolCall", id: state.id, name: state.name, arguments: {} };
-                        output.content.push(block);
-                        stream.push({ type: "toolcall_start", contentIndex: state.contentIndex, partial: output });
-                      }
                       stream.push({
                         type: "toolcall_delta",
                         contentIndex: state.contentIndex,
@@ -487,7 +509,10 @@ export function streamQoder(
         }
       }
 
-      if (toolCallsState.length > 0) {
+      // Guarded on blocks that actually reached the message, not on the state
+      // array being non-empty. Claiming "toolUse" for a message carrying no
+      // tool call is what turned a malformed stream into a silent dead end.
+      if (toolCallsState.some((state) => state?.emittedStart)) {
         output.stopReason = "toolUse";
       }
       // Otherwise keep whatever finish_reason set upstream (defaults to "stop").


### PR DESCRIPTION
## Symptom

A run stops dead, mid-task. The assistant says what it is about to do and then the turn simply ends — no tool executed, no error, nothing in the transcript to explain it. Here it announced *"let me consult the advisor"* four times across six minutes and then stopped.

The final assistant message on disk:

```json
{ "stopReason": "toolUse",
  "content": [ { "type": "text", "text": "I have complete reference data. Let me consult the advisor before building." } ] }
```

`stopReason: "toolUse"` with **no tool call in the message**. pi's agent loop continues only on tool calls, so there was nothing to run and the turn ended.

## Cause

In `src/stream.ts`, the `toolCall` content block is only created inside the arguments branch:

```ts
if (tc.function?.arguments) {          // ← falsy for "" or absent
  state.arguments += argDelta;
  if (state.emittedStart === undefined) {
    ...
    output.content.push(block);        // ← the block is created HERE
  }
}
```

but `toolCallsState[idx]` is created on **any** delta for that index. So a call whose arguments are absent or an empty string — a no-argument tool, or a model that sends `id`+`name` and stops — leaves a state entry and no block. The finalizer then does:

```ts
if (toolCallsState.length > 0) { output.stopReason = "toolUse"; }
```

and the message goes out claiming a tool call it does not contain. This is the only path that can produce that combination.

## Fix

- Open the block as soon as the call is **identifiable** (`id` or `name`), not when the first argument byte arrives. Arguments still accumulate exactly as before, and the finalizer still parses them.
- Keep the block's `id`/`name` in step if they arrive in a later delta, since the finalizer only rewrites `arguments`.
- Guard the stopReason on blocks that actually reached the message rather than on the state array being non-empty, so a genuinely malformed stream reports a clean `stop` instead of an unactionable `toolUse`.

## Tests

Three added to `src/__tests__/stream.test.ts`: a no-argument call, identity arriving after the block is open, and a malformed delta that must not claim `toolUse`. Suite: **119 passing**, biome clean. Verified the tests catch it by restoring the old block placement and stopReason check — 2 fail.

Note: `pnpm run check` fails on `src/oauth.ts:5` (`AuthStorage` no longer exported by `@earendil-works/pi-coding-agent`). Pre-existing on a clean `main`, untouched here.

Independent of #14, which fixes images being dropped from tool results.