### PR TITLE
fix: end the stream at [DONE] and drop orphaned tool results

### DIFF
--- a/src/__tests__/stream.test.ts
+++ b/src/__tests__/stream.test.ts
@@ -290,4 +290,58 @@ describe("streamQoder", () => {
     expect(msg.content.find((c) => c.type === "toolCall")).toBeUndefined();
     expect(msg.stopReason).toBe("stop");
   });
+  it("finishes when the gateway sends [DONE] but keeps the body open", async () => {
+    // Qoder's gateway does not always close the HTTP body after the sentinel.
+    // The read loop used to keep awaiting reader.read() until the socket went
+    // away, so a fully streamed reply never produced a done event and the
+    // agent appeared to hang with no error.
+    const sse = sseEnvelope(chunk({ content: "OK", role: "assistant" })) + sseEnvelope(finishChunk("stop")) + DONE_SSE;
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(sse));
+        // Deliberately never call controller.close().
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    globalThis.fetch = vi.fn(
+      async () => new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } }),
+    ) as unknown as typeof fetch;
+
+    const stream = streamQoder(makeModel(), makeContext(), { apiKey: "fake" });
+    const events = await consume(stream);
+
+    const done = events.find((e) => e.type === "done");
+    expect(done, "expected a done event even though the body stayed open").toBeDefined();
+    const msg = (done as { message: AssistantMessage }).message;
+    expect(msg.stopReason).toBe("stop");
+    const text = msg.content.find((c) => c.type === "text");
+    expect(text && "text" in text ? text.text : "").toBe("OK");
+    // The reader is released rather than left holding the connection.
+    expect(cancelled).toBe(true);
+  });
+
+  it("finishes on a bare 'data: [DONE]' line with the body left open", async () => {
+    // Same sentinel, unwrapped.
+    const sse = `${sseEnvelope(chunk({ content: "hi", role: "assistant" }))}data: [DONE]\n\n`;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(sse));
+      },
+    });
+    globalThis.fetch = vi.fn(
+      async () => new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } }),
+    ) as unknown as typeof fetch;
+
+    const stream = streamQoder(makeModel(), makeContext(), { apiKey: "fake" });
+    const events = await consume(stream);
+
+    const done = events.find((e) => e.type === "done");
+    expect(done, "expected a done event for the bare sentinel").toBeDefined();
+    const msg = (done as { message: AssistantMessage }).message;
+    const text = msg.content.find((c) => c.type === "text");
+    expect(text && "text" in text ? text.text : "").toBe("hi");
+  });
 });

--- a/src/__tests__/transform.test.ts
+++ b/src/__tests__/transform.test.ts
@@ -348,4 +348,56 @@ describe("transformMessagesForQoder", () => {
     expect(tool.role).toBe("tool");
     expect(tool.tool_call_id).toBe("call_abc123");
   });
+  it("drops the tool result whose assistant turn was aborted", () => {
+    // Cancelling a turn mid-tool used to drop only the assistant message and
+    // keep its tool result, leaving a `tool` message with no matching
+    // tool_calls. Upstreams reject that with "tool must follow a message with
+    // tool_calls", so every later request in the session failed.
+    const msgs = [
+      { role: "user", content: "go" },
+      {
+        role: "assistant",
+        stopReason: "aborted",
+        content: [{ type: "toolCall", id: "call_gone", name: "bash", arguments: {} }],
+      },
+      { role: "toolResult", toolCallId: "call_gone", content: "output" },
+      { role: "user", content: "again" },
+    ] as unknown as Message[];
+    const result = transformMessagesForQoder(msgs);
+
+    expect(result.map((m) => (m as { role: string }).role)).toEqual(["user", "user"]);
+    expect(result.some((m) => (m as { role: string }).role === "tool")).toBe(false);
+  });
+
+  it("keeps a healthy tool round-trip while dropping an aborted one", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        stopReason: "error",
+        content: [{ type: "toolCall", id: "call_bad", name: "x", arguments: {} }],
+      },
+      { role: "toolResult", toolCallId: "call_bad", content: "r1" },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_good", name: "y", arguments: {} }],
+      },
+      { role: "toolResult", toolCallId: "call_good", content: "r2" },
+    ] as unknown as Message[];
+    const result = transformMessagesForQoder(msgs);
+
+    expect(result).toHaveLength(2);
+    const asst = result[0] as { tool_calls?: Array<{ id: string }> };
+    const tool = result[1] as { role: string; tool_call_id: string };
+    expect(asst.tool_calls?.map((t) => t.id)).toEqual(["call_good"]);
+    expect(tool.tool_call_id).toBe("call_good");
+
+    // Every tool message must have a declaring tool_calls entry.
+    const declared = new Set(
+      result.flatMap((m) => ((m as { tool_calls?: Array<{ id: string }> }).tool_calls ?? []).map((t) => t.id)),
+    );
+    for (const m of result) {
+      const tm = m as { role: string; tool_call_id?: string };
+      if (tm.role === "tool") expect(declared.has(tm.tool_call_id as string)).toBe(true);
+    }
+  });
 });

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -273,7 +273,14 @@ export function streamQoder(
 
       stream.push({ type: "start", partial: output });
 
-      while (true) {
+      // `data: [DONE]` is the end of the response. Break the read loop too, not
+      // just the line loop: Qoder's gateway keeps the HTTP body open after the
+      // sentinel, so waiting for `done` from reader.read() hung until the
+      // server or the OS eventually closed the socket. The full reply had
+      // already been streamed by then, so the agent looked stuck with no error.
+      let sawDone = false;
+
+      while (!sawDone) {
         const { done, value } = await reader.read();
         if (done) break;
 
@@ -290,6 +297,7 @@ export function streamQoder(
 
           const dataStr = line.substring(5).trim();
           if (dataStr === "[DONE]") {
+            sawDone = true;
             break;
           }
 
@@ -300,7 +308,14 @@ export function streamQoder(
             }
 
             const innerStr = envelope.body;
-            if (!innerStr || innerStr === "[DONE]") continue;
+            // The gateway sends the sentinel wrapped in an envelope
+            // (`body: "[DONE]"`) as well as bare, and both mean the reply is
+            // over, so both have to end the read loop.
+            if (innerStr === "[DONE]") {
+              sawDone = true;
+              break;
+            }
+            if (!innerStr) continue;
 
             const inner = JSON.parse(innerStr);
             if (inner.id) output.responseId = inner.id as string;
@@ -471,6 +486,10 @@ export function streamQoder(
           }
         }
       }
+
+      // Stop reading and let the connection go once the reply is complete.
+      // Without this the body stays open until the server times it out.
+      await reader.cancel().catch(() => {});
 
       if (thinkingParser) {
         thinkingParser.finalize();

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -72,12 +72,33 @@ export function transformTools(tools: Tool[]): QoderTool[] {
 export function transformMessagesForQoder(messages: Message[]): QoderMessage[] {
   const normalizedMessages: QoderMessage[] = [];
 
+  // Dropping an assistant turn (below) also invalidates its tool calls: the
+  // result that follows would refer to a tool_calls entry that is no longer in
+  // the request, and upstreams reject that with "tool must follow a message
+  // with tool_calls".
+  const droppedToolCallIds = new Set<string>();
+
   for (const msg of messages) {
     // Skip error or aborted messages
     if (
       msg.role === "assistant" &&
       ((msg as AssistantMessage).stopReason === "error" || (msg as AssistantMessage).stopReason === "aborted")
     ) {
+      const am = msg as AssistantMessage;
+      if (Array.isArray(am.content)) {
+        for (const block of am.content) {
+          if (block.type === "toolCall") {
+            const id = (block as ToolCall).id;
+            if (id) droppedToolCallIds.add(id);
+          }
+        }
+      }
+      continue;
+    }
+
+    // Drop the result too, otherwise it refers to a tool_calls entry that is
+    // no longer in the request.
+    if (msg.role === "toolResult" && droppedToolCallIds.has((msg as ToolResultMessage).toolCallId)) {
       continue;
     }
 


### PR DESCRIPTION
Two independent bugs, each reproducible on `main`, that together made Qoder turns hang or fail outright. Both come with regression tests that fail before the fix.

## 1. The stream never ends at `[DONE]`

`data: [DONE]` broke only the inner line loop, so the outer loop went back to `await reader.read()` and waited for the body to close. Qoder's gateway keeps the connection open after the sentinel, so the reply — already fully streamed and parsed — never produced a `done` event. The agent sat with the complete answer buffered and no error until something else timed the socket out.

The sentinel also arrives wrapped in an envelope (`body: "[DONE]"`), which likewise only did `continue`. That is in fact the shape the existing tests use (`DONE_SSE`), so both forms now end the read loop. The reader is also cancelled once the reply is complete rather than left holding the connection.

Reproduction, using a response body that never closes:

```
data: {...,"body":"{\"choices\":[{\"delta\":{\"content\":\"OK\"}}]}"}
data: {...,"body":"{\"choices\":[{\"finish_reason\":\"stop\"}]}"}
data: {...,"body":"[DONE]"}
<body stays open>
```

Before: no `done` event; the new tests hit the 8s test timeout.
After: `done` with `stopReason: "stop"` and text `"OK"`, and the reader is cancelled.

## 2. Aborting a turn makes every later request in the session fail

Assistant messages with `stopReason` `error`/`aborted` are skipped, but the `toolResult` that followed was still emitted. That leaves a `tool` message whose `tool_call_id` has no matching `tool_calls` entry anywhere in the request, and upstreams reject it with *"tool must follow a message with tool_calls"* — the same failure the null-content placeholder just above already guards against. So one cancelled tool call poisoned the rest of the session.

```js
[
  { role: "user", content: "go" },
  { role: "assistant", stopReason: "aborted",
    content: [{ type: "toolCall", id: "call_gone", name: "bash", arguments: {} }] },
  { role: "toolResult", toolCallId: "call_gone", content: "output" },
  { role: "user", content: "again" },
]
```

Before: `["user", "tool", "user"]` — an orphaned `tool` message.
After: `["user", "user"]`.

Tool calls belonging to a dropped turn are recorded so their results are dropped with them.

## Scope

I deliberately kept this to the two clear correctness bugs. While testing I also tried dropping tool calls that never received a result (the mirror case), but that broke two existing tests which assert a trailing tool-call-only assistant message is preserved, so I dropped that idea — it looks like intended behaviour.

## Validation

- `vitest run` — 126 passed (122 pre-existing unchanged, 4 new)
- `tsc --noEmit` — clean
- `biome check` on the touched files — clean
- esbuild bundle — succeeds
- Confirmed the 4 new tests fail on unpatched `main`: the two stream tests time out at 8s, the two transform tests produce the orphaned `tool` message
