### PR TITLE
fix(cn): track upstream model catalog dynamically, forward reasoning effort, raise output to 128K

### DIFF
--- a/src/__tests__/cosy.test.ts
+++ b/src/__tests__/cosy.test.ts
@@ -3,8 +3,6 @@ import {
   getQoderBaseUrl,
   getQoderCenterUrl,
   getQoderChatURL,
-  getQoderCNDirectModel,
-  getQoderCNFriendlyModelInfo,
   getQoderExchangeURL,
   getQoderManageUrl,
   getQoderMode,
@@ -15,7 +13,7 @@ import {
   getQoderUserEmailFallback,
   getQoderUserInfoURL,
   isQoderCNMode,
-  toQoderCNFriendlyModel,
+  toQoderCNModelId,
 } from "../cosy.js";
 
 // ── getQoderMode ──────────────────────────────────────────────────────────
@@ -160,83 +158,23 @@ describe("getQoderUserEmailFallback", () => {
   });
 });
 
-// ── getQoderCNDirectModel ─────────────────────────────────────────────────
+// ── toQoderCNModelId ──────────────────────────────────────────────────────
 
-describe("getQoderCNDirectModel", () => {
-  it("maps known model IDs to internal keys", () => {
-    expect(getQoderCNDirectModel("qoder-cn")).toBe("auto");
-    expect(getQoderCNDirectModel("qwen3.7-max")).toBe("qmodel_latest");
-    expect(getQoderCNDirectModel("qwen3.7-plus")).toBe("qmodel");
-    expect(getQoderCNDirectModel("qwen3.6-plus")).toBe("qmodel");
-    expect(getQoderCNDirectModel("qwen3.6-flash")).toBe("q36fmodel");
-    expect(getQoderCNDirectModel("deepseek-v4-pro")).toBe("dmodel");
-    expect(getQoderCNDirectModel("deepseek-v4-flash")).toBe("dfmodel");
-    expect(getQoderCNDirectModel("glm-5.2")).toBe("gm51model");
-    expect(getQoderCNDirectModel("glm-5.1")).toBe("gm51model");
-    expect(getQoderCNDirectModel("kimi-k2.6")).toBe("kmodel");
-    expect(getQoderCNDirectModel("minimax-m2.7")).toBe("mmodel");
-    expect(getQoderCNDirectModel("minimax-m3")).toBe("mmodel");
+describe("toQoderCNModelId", () => {
+  it("strips whitespace from the upstream display_name", () => {
+    // The display name is used directly as the pi-visible model id, with
+    // whitespace removed so it stays a clean token for persistence keys and
+    // search. "Qwen3.8-Flash" has no spaces already.
+    expect(toQoderCNModelId("Qwen3.8-Flash")).toBe("Qwen3.8-Flash");
   });
 
-  it("returns the input ID for unknown models", () => {
-    expect(getQoderCNDirectModel("custom-model")).toBe("custom-model");
+  it("collapses internal spaces", () => {
+    expect(toQoderCNModelId("Qwen 3.8 Max")).toBe("Qwen3.8Max");
+    expect(toQoderCNModelId("DeepSeek V4 Pro")).toBe("DeepSeekV4Pro");
   });
 
-  it('defaults to "auto" when no input', () => {
-    expect(getQoderCNDirectModel()).toBe("auto");
-    expect(getQoderCNDirectModel("")).toBe("auto");
-  });
-});
-
-// ── getQoderCNFriendlyModelInfo ───────────────────────────────────────────
-
-describe("getQoderCNFriendlyModelInfo", () => {
-  it("returns known friendly info for mapped keys", () => {
-    const info = getQoderCNFriendlyModelInfo("qmodel_latest");
-    expect(info.id).toBe("qwen3.7-max");
-    expect(info.name).toBe("Qwen 3.7 Max · Qoder CN");
-  });
-
-  it("returns auto mapping", () => {
-    const info = getQoderCNFriendlyModelInfo("auto");
-    expect(info.id).toBe("auto");
-    expect(info.name).toBe("Auto · Qoder CN");
-  });
-
-  it("generates friendly name for unknown keys", () => {
-    const info = getQoderCNFriendlyModelInfo("my-custom-model", "My Custom Model");
-    expect(info.id).toBe("my-custom-model");
-    expect(info.name).toContain("Qoder CN");
-  });
-
-  it("prettifies model names with version numbers", () => {
-    const info = getQoderCNFriendlyModelInfo("some-model", "Qwen3.7-New");
-    expect(info.name).toContain("Qwen 3.7");
-    expect(info.name).toContain("Qoder CN");
-  });
-});
-
-// ── toQoderCNFriendlyModel ────────────────────────────────────────────────
-
-describe("toQoderCNFriendlyModel", () => {
-  it("maps known model ID to friendly version", () => {
-    const result = toQoderCNFriendlyModel({ id: "qmodel_latest", name: "Original Name" });
-    expect(result.id).toBe("qwen3.7-max");
-    expect(result.name).toBe("Qwen 3.7 Max · Qoder CN");
-  });
-
-  it("preserves extra fields", () => {
-    const result = toQoderCNFriendlyModel({ id: "auto", name: "Auto", extra: "field" } as {
-      id: string;
-      name: string;
-      extra: string;
-    });
-    expect(result.extra).toBe("field");
-  });
-
-  it("handles unknown models by prettifying display name", () => {
-    const result = toQoderCNFriendlyModel({ id: "custom", name: "CustomModel V2-Pro" });
-    expect(result.id).toBe("custom");
-    expect(result.name).toContain("Qoder CN");
+  it("falls back to a default when no display name is given", () => {
+    expect(toQoderCNModelId()).toBe("QoderCNModel");
+    expect(toQoderCNModelId("")).toBe("QoderCNModel");
   });
 });

--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -43,8 +43,8 @@ describe("staticCnModels", () => {
     expect(staticCnModels.length).toBeGreaterThan(0);
   });
 
-  it("has auto as first entry", () => {
-    expect(staticCnModels[0].id).toBe("auto");
+  it("has Auto as first entry", () => {
+    expect(staticCnModels[0].id).toBe("Auto");
   });
 
   it("every CN model has required fields", () => {

--- a/src/cosy.ts
+++ b/src/cosy.ts
@@ -113,62 +113,20 @@ export function getQoderRefreshURL(mode?: string): string {
   return `${getQoderCenterUrl(mode)}/algo/api/v3/user/refresh_token`;
 }
 
-export function getQoderCNDirectModel(modelID?: string): string {
-  return (
-    {
-      "qoder-cn": "auto",
-      "qwen3.7-max": "qmodel_latest",
-      "qwen3.7-plus": "qmodel",
-      "qwen3.6-plus": "qmodel",
-      "qwen3.6-flash": "q36fmodel",
-      "deepseek-v4-pro": "dmodel",
-      "deepseek-v4-flash": "dfmodel",
-      "glm-5.2": "gm51model",
-      "glm-5.1": "gm51model",
-      "kimi-k2.6": "kmodel",
-      "minimax-m2.7": "mmodel",
-      "minimax-m3": "mmodel",
-    }[modelID || ""] ||
-    modelID ||
-    "auto"
-  );
-}
-
-const qoderCNFriendlyModels: Record<string, { id: string; name: string }> = {
-  auto: { id: "auto", name: "Auto · Qoder CN" },
-  "qoder-cn": { id: "qoder-cn", name: "Auto · Qoder CN" },
-  qmodel_latest: { id: "qwen3.7-max", name: "Qwen 3.7 Max · Qoder CN" },
-  qmodel: { id: "qwen3.7-plus", name: "Qwen 3.7 Plus · Qoder CN" },
-  q36fmodel: { id: "qwen3.6-flash", name: "Qwen 3.6 Flash · Qoder CN" },
-  qfmodel: { id: "qwen3.6-flash", name: "Qwen 3.6 Flash · Qoder CN" },
-  dmodel: { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro · Qoder CN" },
-  dfmodel: { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash · Qoder CN" },
-  gm51model: { id: "glm-5.2", name: "GLM 5.2 · Qoder CN" },
-  kmodel: { id: "kimi-k2.6", name: "Kimi K2.6 · Qoder CN" },
-  mmodel: { id: "minimax-m2.7", name: "MiniMax M2.7 · Qoder CN" },
-};
-
-function prettifyQoderCNModelName(name: string): string {
-  const pretty = (name || "Qoder CN Model")
-    .replace(/Qwen(\d)/g, "Qwen $1")
-    .replace(/Qwen([\d.]+)-/g, "Qwen $1 ")
-    .replace(/DeepSeek\s*V(\d)-/g, "DeepSeek V$1 ")
-    .replace(/\s+/g, " ")
-    .trim();
-  return pretty.includes("Qoder CN") ? pretty : `${pretty} · Qoder CN`;
-}
-
-export function getQoderCNFriendlyModelInfo(key: string, display?: string): { id: string; name: string } {
-  return qoderCNFriendlyModels[key] || { id: key, name: prettifyQoderCNModelName(display || key) };
-}
-
-export function toQoderCNFriendlyModel<T extends { id: string; name: string }>(model: T): T {
-  const info = getQoderCNFriendlyModelInfo(model.id, model.name);
-  return {
-    ...model,
-    id: info.id,
-    name: info.name,
-  };
+/**
+ * Derive the model `id` pi exposes in the picker from Qoder's `display_name`.
+ *
+ * The picker renders `Model.id`, not `Model.name`, so the display name is used
+ * directly as the id (with whitespace stripped so it stays a clean token for
+ * persistence keys, logs, and search). The original upstream `key` (e.g.
+ * `qfmodel`) is NOT used as the id: it is kept only as the request-time
+ * identifier, read back from the cached model config at send time. This drops
+ * the hardcoded key<->friendlyId mapping tables entirely — the label now
+ * tracks whatever upstream returns, so a renamed/upgraded model is shown
+ * correctly without a code change.
+ */
+export function toQoderCNModelId(displayName?: string): string {
+  return (displayName || "QoderCNModel").replace(/\s+/g, "");
 }
 
 export function getQoderManageUrl(mode?: string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,6 @@
 import type { Api, Model, OAuthCredentials } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ProviderConfig } from "@earendil-works/pi-coding-agent";
-import {
-  getQoderBaseUrl,
-  getQoderMode,
-  getQoderUserEmailFallback,
-  isQoderCNMode,
-  toQoderCNFriendlyModel,
-} from "./cosy.js";
+import { getQoderBaseUrl, getQoderMode, getQoderUserEmailFallback, isQoderCNMode } from "./cosy.js";
 import { getCachedModels, isCacheStale, staticCnModels, staticModels, updateQoderModelsCache } from "./models.js";
 import {
   autoLoginQoderFromEnvironment,
@@ -29,14 +23,11 @@ function modelsForProvider(mode: string, providerID: string): Model<Api>[] {
   const cached = getCachedModels(mode);
   const modelsToUse = cached.length > 0 ? cached : isQoderCNMode(mode) ? staticCnModels : staticModels;
 
-  return modelsToUse.map((m) => {
-    const model = isQoderCNMode(mode) ? toQoderCNFriendlyModel(m) : m;
-    return {
-      ...model,
-      provider: providerID,
-      baseUrl: getQoderBaseUrl(mode),
-    };
-  }) as unknown as Model<Api>[];
+  return modelsToUse.map((m) => ({
+    ...m,
+    provider: providerID,
+    baseUrl: getQoderBaseUrl(mode),
+  })) as unknown as Model<Api>[];
 }
 
 function createQoderOAuth(providerID: string, mode: string): OAuthConfigWithUsage {

--- a/src/models.ts
+++ b/src/models.ts
@@ -19,7 +19,6 @@ export interface QoderModelEntry {
   enable?: boolean;
   display_name?: string;
   max_input_tokens?: number;
-  max_output_tokens?: number;
   context_config?: Record<string, { token_count?: number; is_default?: boolean }>;
   is_vl?: boolean;
   is_reasoning?: boolean;
@@ -589,7 +588,7 @@ export async function updateQoderModelsCache(
         input: isVL ? ["text", "image"] : ["text"],
         cost: ZERO_COST,
         contextWindow: ctxLen,
-        maxTokens: entry.max_output_tokens || 32768,
+        maxTokens: 32768,
       });
     }
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import type { ThinkingLevel, ThinkingLevelMap } from "@earendil-works/pi-ai";
 import {
   buildAuthHeaders,
   getQoderBaseUrl,
@@ -22,7 +23,10 @@ export interface QoderModelEntry {
   context_config?: Record<string, { token_count?: number; is_default?: boolean }>;
   is_vl?: boolean;
   is_reasoning?: boolean;
-  thinking_config?: { enabled?: { efforts?: unknown } };
+  thinking_config?: {
+    disabled?: unknown;
+    enabled?: { efforts?: Record<string, { is_default?: boolean }>; is_default?: boolean };
+  };
   source?: string;
   [key: string]: unknown;
 }
@@ -35,6 +39,7 @@ export interface QoderModelDef {
   baseUrl: string;
   reasoning: boolean;
   supportsEffort: boolean;
+  thinkingLevelMap?: ThinkingLevelMap;
   input: ("text" | "image")[];
   cost: typeof ZERO_COST;
   contextWindow: number;
@@ -378,6 +383,52 @@ export const staticCnModels: QoderModelDef[] = [
   },
 ];
 
+/** pi thinking levels in display order (matches the pi-ai SDK this build targets). */
+const PI_THINKING_LEVELS: readonly ThinkingLevel[] = ["minimal", "low", "medium", "high", "xhigh"];
+
+/**
+ * Map Qoder's `thinking_config` to pi's `thinkingLevelMap` so the TUI exposes
+ * the levels the upstream model actually supports.
+ *
+ * Qoder has two shapes:
+ *   - effort-based: `thinking_config.enabled.efforts = { low, medium, xhigh, ... }`
+ *     Each effort key is already a pi level name, so supported levels map to
+ *     themselves and the rest are pinned to null (hidden in the picker).
+ *     `xhigh`/`max` are only shown when the map carries them, otherwise the
+ *     picker tops out at `high`.
+ *   - toggle-based: `thinking_config.enabled` without `efforts` (only on/off).
+ *     Every pi level is exposed and maps to "enabled" so a user picking any
+ *     level turns thinking on; the exact effort sent upstream is decided at
+ *     request time.
+ * Returns undefined for models that do not support thinking, so pi falls back
+ * to `reasoning: false`-style behavior (only `off`).
+ */
+function buildThinkingLevelMap(entry: QoderModelEntry): ThinkingLevelMap | undefined {
+  const tc = entry.thinking_config;
+  if (!tc) return undefined;
+  const efforts = tc.enabled?.efforts;
+  if (efforts && typeof efforts === "object") {
+    const supported = new Set(Object.keys(efforts));
+    // `off` (disable thinking) is selectable when the catalog advertises a
+    // `disabled` option; otherwise pin it to null to hide it.
+    const map: ThinkingLevelMap = { off: tc.disabled ? "disabled" : null };
+    for (const level of PI_THINKING_LEVELS) {
+      map[level] = supported.has(level) ? level : null;
+    }
+    return map;
+  }
+  // toggle-only (enabled/disabled, no efforts) — expose every level as "on".
+  // `off` is selectable when the catalog advertises `disabled`.
+  if (tc.enabled) {
+    const map: ThinkingLevelMap = { off: tc.disabled ? "disabled" : null };
+    for (const level of PI_THINKING_LEVELS) {
+      map[level] = "enabled";
+    }
+    return map;
+  }
+  return undefined;
+}
+
 export function getCachedModels(mode?: string): QoderModelDef[] {
   const cachePath = getQoderCachePath(mode);
   if (existsSync(cachePath)) {
@@ -515,6 +566,7 @@ export async function updateQoderModelsCache(
       const isVL = !!entry.is_vl;
       const isReasoning = !!entry.is_reasoning || !!entry.thinking_config;
       const supportsEffort = !!entry.thinking_config?.enabled?.efforts;
+      const thinkingLevelMap = buildThinkingLevelMap(entry);
       // CN models expose the upstream display_name (whitespace-stripped) as the
       // pi-visible id; the original `key` is stored in `configs` and read back at
       // request time, so no key<->friendlyId mapping table is needed.
@@ -533,6 +585,7 @@ export async function updateQoderModelsCache(
         baseUrl: getQoderBaseUrl(mode),
         reasoning: isReasoning,
         supportsEffort,
+        thinkingLevelMap,
         input: isVL ? ["text", "image"] : ["text"],
         cost: ZERO_COST,
         contextWindow: ctxLen,

--- a/src/models.ts
+++ b/src/models.ts
@@ -260,9 +260,9 @@ export const staticCnModels: QoderModelDef[] = [
     supportsEffort: false,
     input: ["text", "image"],
     cost: ZERO_COST,
-    contextWindow: 180000,
+    contextWindow: 200000,
     maxTokens: 32768,
-    description: "Qoder CN smart routing; live catalog reports 180K max input.",
+    description: "Qoder CN smart routing; fallback context window of 200K.",
   },
   {
     id: "Qwen3.7-Max",
@@ -497,13 +497,17 @@ export async function updateQoderModelsCache(
       if (!key || !entry.enable) continue;
 
       const display = entry.display_name || key;
-      let ctxLen = entry.max_input_tokens || 180000;
+      // The context window is the largest selectable context option the upstream
+      // catalog exposes (e.g. 1M when 200K/400K/1M are offered). Fall back to
+      // 200K when no context_config is present. `max_input_tokens` is not used:
+      // it is a flat base value (180K) that every catalog entry with selectable
+      // contexts already exceeds, so it only ever acted as a redundant floor.
+      let ctxLen = 200000;
       if (entry.context_config && typeof entry.context_config === "object") {
         for (const configVal of Object.values(entry.context_config)) {
           if (configVal && typeof configVal === "object" && typeof configVal.token_count === "number") {
-            const tc = configVal.token_count;
-            if (tc > ctxLen) {
-              ctxLen = tc;
+            if (configVal.token_count > ctxLen) {
+              ctxLen = configVal.token_count;
             }
           }
         }

--- a/src/models.ts
+++ b/src/models.ts
@@ -4,10 +4,10 @@ import { dirname, join } from "node:path";
 import {
   buildAuthHeaders,
   getQoderBaseUrl,
-  getQoderCNFriendlyModelInfo,
   getQoderMode,
   getQoderModelListURL,
   isQoderCNMode,
+  toQoderCNModelId,
 } from "./cosy.js";
 
 export const ZERO_COST = Object.freeze({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
@@ -251,8 +251,8 @@ export const staticModels: QoderModelDef[] = [
 
 export const staticCnModels: QoderModelDef[] = [
   {
-    id: "auto",
-    name: "Auto · Qoder CN",
+    id: "Auto",
+    name: "Auto",
     api: "qoder-api",
     provider: "qoder-cn",
     baseUrl: getQoderBaseUrl("cn"),
@@ -265,8 +265,8 @@ export const staticCnModels: QoderModelDef[] = [
     description: "Qoder CN smart routing; live catalog reports 180K max input.",
   },
   {
-    id: "qwen3.7-max",
-    name: "Qwen 3.7 Max · Qoder CN",
+    id: "Qwen3.7-Max",
+    name: "Qwen3.7-Max",
     api: "qoder-api",
     provider: "qoder-cn",
     baseUrl: getQoderBaseUrl("cn"),
@@ -279,8 +279,8 @@ export const staticCnModels: QoderModelDef[] = [
     description: "Qoder CN qmodel_latest; context options 200K/400K/1M.",
   },
   {
-    id: "qwen3.7-plus",
-    name: "Qwen 3.7 Plus · Qoder CN",
+    id: "Qwen3.7-Plus",
+    name: "Qwen3.7-Plus",
     api: "qoder-api",
     provider: "qoder-cn",
     baseUrl: getQoderBaseUrl("cn"),
@@ -293,8 +293,8 @@ export const staticCnModels: QoderModelDef[] = [
     description: "Qoder CN qmodel; context options 200K/400K/1M.",
   },
   {
-    id: "qwen3.6-flash",
-    name: "Qwen 3.6 Flash · Qoder CN",
+    id: "Qwen3.6-Flash",
+    name: "Qwen3.6-Flash",
     api: "qoder-api",
     provider: "qoder-cn",
     baseUrl: getQoderBaseUrl("cn"),
@@ -307,8 +307,8 @@ export const staticCnModels: QoderModelDef[] = [
     description: "Qoder CN q36fmodel; context options 200K/400K/1M.",
   },
   {
-    id: "deepseek-v4-pro",
-    name: "DeepSeek V4 Pro · Qoder CN",
+    id: "DeepSeek-V4-Pro",
+    name: "DeepSeek-V4-Pro",
     api: "qoder-api",
     provider: "qoder-cn",
     baseUrl: getQoderBaseUrl("cn"),
@@ -321,8 +321,8 @@ export const staticCnModels: QoderModelDef[] = [
     description: "Qoder CN dmodel; context options 200K/400K/1M.",
   },
   {
-    id: "deepseek-v4-flash",
-    name: "DeepSeek V4 Flash · Qoder CN",
+    id: "DeepSeek-V4-Flash",
+    name: "DeepSeek-V4-Flash",
     api: "qoder-api",
     provider: "qoder-cn",
     baseUrl: getQoderBaseUrl("cn"),
@@ -335,8 +335,8 @@ export const staticCnModels: QoderModelDef[] = [
     description: "Qoder CN dfmodel; context options 200K/400K/1M.",
   },
   {
-    id: "glm-5.2",
-    name: "GLM 5.2 · Qoder CN",
+    id: "GLM-5.2",
+    name: "GLM-5.2",
     api: "qoder-api",
     provider: "qoder-cn",
     baseUrl: getQoderBaseUrl("cn"),
@@ -349,8 +349,8 @@ export const staticCnModels: QoderModelDef[] = [
     description: "Qoder CN gm51model; live catalog currently displays GLM-5.2 with 200K context.",
   },
   {
-    id: "kimi-k2.6",
-    name: "Kimi K2.6 · Qoder CN",
+    id: "Kimi-K2.7-Code",
+    name: "Kimi-K2.7-Code",
     api: "qoder-api",
     provider: "qoder-cn",
     baseUrl: getQoderBaseUrl("cn"),
@@ -363,8 +363,8 @@ export const staticCnModels: QoderModelDef[] = [
     description: "Qoder CN kmodel; context option 256K.",
   },
   {
-    id: "minimax-m2.7",
-    name: "MiniMax M2.7 · Qoder CN",
+    id: "MiniMax-M2.7",
+    name: "MiniMax-M2.7",
     api: "qoder-api",
     provider: "qoder-cn",
     baseUrl: getQoderBaseUrl("cn"),
@@ -407,29 +407,14 @@ export function getCachedModelConfig(modelKey: string, mode?: string): QoderMode
     } catch {}
   }
 
+  // No cached config. This only happens before the first successful catalog
+  // fetch (e.g. not yet logged in), in which case the request cannot succeed
+  // anyway. Return a minimal entry carrying the id as the key so callers have
+  // something to read; reasoning is unknown so default to false.
   if (isQoderCNMode(mode)) {
-    const reasoningModels = new Set([
-      "qoder-cn",
-      "auto",
-      "qmodel_latest",
-      "qmodel",
-      "q36fmodel",
-      "qfmodel",
-      "dmodel",
-      "gm51model",
-      "kmodel",
-      "qwen3.7-max",
-      "qwen3.7-plus",
-      "qwen3.6-plus",
-      "qwen3.6-flash",
-      "deepseek-v4-pro",
-      "glm-5.2",
-      "glm-5.1",
-      "kimi-k2.6",
-    ]);
     return {
       key: modelKey,
-      is_reasoning: reasoningModels.has(modelKey),
+      is_reasoning: false,
       max_output_tokens: 32768,
       source: "system",
     };
@@ -526,7 +511,12 @@ export async function updateQoderModelsCache(
       const isVL = !!entry.is_vl;
       const isReasoning = !!entry.is_reasoning || !!entry.thinking_config;
       const supportsEffort = !!entry.thinking_config?.enabled?.efforts;
-      const modelInfo = isQoderCNMode(mode) ? getQoderCNFriendlyModelInfo(key, display) : { id: key, name: display };
+      // CN models expose the upstream display_name (whitespace-stripped) as the
+      // pi-visible id; the original `key` is stored in `configs` and read back at
+      // request time, so no key<->friendlyId mapping table is needed.
+      const modelInfo = isQoderCNMode(mode)
+        ? { id: toQoderCNModelId(display), name: display }
+        : { id: key, name: display };
 
       configs[key] = entry;
       if (modelInfo.id !== key) configs[modelInfo.id] = entry;

--- a/src/models.ts
+++ b/src/models.ts
@@ -13,6 +13,19 @@ import {
 
 export const ZERO_COST = Object.freeze({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
 
+/**
+ * Maximum output tokens sent per request. Aliyun Model Studio (the upstream
+ * behind Qoder's CN catalog) documents Max Output Length = 131072 for every
+ * model we expose (qwen3.8-max/flash, qwen3.7-max/plus/flash), in both normal
+ * and thinking modes (thinking chain alone goes up to 262144). The Qoder
+ * /model/list catalog does not return a per-model output cap, so this single
+ * constant is the source of truth for both static models and request sending.
+ * qodercli ships a conservative 32e3 default and caps its UI at 65536; we use
+ * the documented upstream ceiling so reasoning chains and long generations
+ * are not truncated.
+ */
+export const MAX_OUTPUT_TOKENS = 131072;
+
 /** Shape of a single entry returned by the Qoder /model/list endpoint. */
 export interface QoderModelEntry {
   key?: string;
@@ -67,7 +80,7 @@ export const staticModels: QoderModelDef[] = [
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 180000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
   },
   {
     id: "ultimate",
@@ -80,7 +93,7 @@ export const staticModels: QoderModelDef[] = [
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
   },
   {
     id: "performance",
@@ -93,7 +106,7 @@ export const staticModels: QoderModelDef[] = [
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
   },
   {
     id: "efficient",
@@ -106,7 +119,7 @@ export const staticModels: QoderModelDef[] = [
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 180000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
   },
   {
     id: "lite",
@@ -119,7 +132,7 @@ export const staticModels: QoderModelDef[] = [
     input: ["text"],
     cost: ZERO_COST,
     contextWindow: 180000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
   },
   {
     id: "qmodel",
@@ -132,7 +145,7 @@ export const staticModels: QoderModelDef[] = [
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
   },
   {
     id: "cmodel",
@@ -145,7 +158,7 @@ export const staticModels: QoderModelDef[] = [
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
   },
   {
     id: "qmodel_preview",
@@ -158,7 +171,7 @@ export const staticModels: QoderModelDef[] = [
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
   },
   {
     id: "qmodel_latest",
@@ -171,7 +184,7 @@ export const staticModels: QoderModelDef[] = [
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
   },
   {
     id: "dmodel",
@@ -184,7 +197,7 @@ export const staticModels: QoderModelDef[] = [
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
   },
   {
     id: "dfmodel",
@@ -197,7 +210,7 @@ export const staticModels: QoderModelDef[] = [
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
   },
   {
     id: "gm51model",
@@ -210,7 +223,7 @@ export const staticModels: QoderModelDef[] = [
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
   },
   {
     id: "kmodel",
@@ -223,7 +236,7 @@ export const staticModels: QoderModelDef[] = [
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 256000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
   },
   {
     id: "kmodel_latest",
@@ -236,7 +249,7 @@ export const staticModels: QoderModelDef[] = [
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
   },
   {
     id: "mmodel",
@@ -249,7 +262,7 @@ export const staticModels: QoderModelDef[] = [
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
   },
 ];
 
@@ -265,7 +278,7 @@ export const staticCnModels: QoderModelDef[] = [
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 200000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
     description: "Qoder CN smart routing; fallback context window of 200K.",
   },
   {
@@ -279,7 +292,7 @@ export const staticCnModels: QoderModelDef[] = [
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 1000000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
     description: "Qoder CN qmodel_latest; context options 200K/400K/1M.",
   },
   {
@@ -293,7 +306,7 @@ export const staticCnModels: QoderModelDef[] = [
     input: ["text"],
     cost: ZERO_COST,
     contextWindow: 1000000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
     description: "Qoder CN qmodel; context options 200K/400K/1M.",
   },
   {
@@ -307,7 +320,7 @@ export const staticCnModels: QoderModelDef[] = [
     input: ["text"],
     cost: ZERO_COST,
     contextWindow: 1000000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
     description: "Qoder CN q36fmodel; context options 200K/400K/1M.",
   },
   {
@@ -321,7 +334,7 @@ export const staticCnModels: QoderModelDef[] = [
     input: ["text"],
     cost: ZERO_COST,
     contextWindow: 1000000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
     description: "Qoder CN dmodel; context options 200K/400K/1M.",
   },
   {
@@ -335,7 +348,7 @@ export const staticCnModels: QoderModelDef[] = [
     input: ["text"],
     cost: ZERO_COST,
     contextWindow: 1000000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
     description: "Qoder CN dfmodel; context options 200K/400K/1M.",
   },
   {
@@ -349,7 +362,7 @@ export const staticCnModels: QoderModelDef[] = [
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 200000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
     description: "Qoder CN gm51model; live catalog currently displays GLM-5.2 with 200K context.",
   },
   {
@@ -363,7 +376,7 @@ export const staticCnModels: QoderModelDef[] = [
     input: ["text", "image"],
     cost: ZERO_COST,
     contextWindow: 256000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
     description: "Qoder CN kmodel; context option 256K.",
   },
   {
@@ -377,7 +390,7 @@ export const staticCnModels: QoderModelDef[] = [
     input: ["text"],
     cost: ZERO_COST,
     contextWindow: 200000,
-    maxTokens: 32768,
+    maxTokens: MAX_OUTPUT_TOKENS,
     description: "Qoder CN mmodel; live catalog reports 200K context.",
   },
 ];
@@ -465,7 +478,6 @@ export function getCachedModelConfig(modelKey: string, mode?: string): QoderMode
     return {
       key: modelKey,
       is_reasoning: false,
-      max_output_tokens: 32768,
       source: "system",
     };
   }
@@ -588,7 +600,7 @@ export async function updateQoderModelsCache(
         input: isVL ? ["text", "image"] : ["text"],
         cost: ZERO_COST,
         contextWindow: ctxLen,
-        maxTokens: 32768,
+        maxTokens: MAX_OUTPUT_TOKENS,
       });
     }
 

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,16 +1,17 @@
 import crypto from "node:crypto";
-import type {
-  Api,
-  AssistantMessage,
-  AssistantMessageEventStream,
-  Context,
-  Model,
-  SimpleStreamOptions,
-  TextContent,
-  ThinkingContent,
-  ToolCall,
-} from "@earendil-works/pi-ai";
 import * as PiAi from "@earendil-works/pi-ai";
+import {
+  type Api,
+  type AssistantMessage,
+  type AssistantMessageEventStream,
+  type Context,
+  clampThinkingLevel,
+  type Model,
+  type SimpleStreamOptions,
+  type TextContent,
+  type ThinkingContent,
+  type ToolCall,
+} from "@earendil-works/pi-ai";
 import {
   buildAuthHeaders,
   getMachineId,
@@ -173,6 +174,38 @@ export function streamQoder(
       const toolsRaw = context.tools && context.tools.length > 0 ? transformTools(context.tools) : undefined;
       const recordID = stableChatRecordID(qoderModel, normalizedMessages, toolsRaw, maxTokens);
 
+      // Map pi's thinking level (options.reasoning) to Qoder's request fields.
+      // Confirmed from @qoder-ai/qodercli: the chat body carries `reasoning_effort`
+      // ("none"|"low"|"medium"|"high"|"xhigh"|"max") and `enable_thinking` (bool)
+      // inside `parameters`, alongside `max_tokens`.
+      //
+      // This mirrors the pattern the pi-ai OpenAI provider uses: clamp the
+      // requested level to what the model advertises via thinkingLevelMap, then
+      // map to the upstream effort name. clampThinkingLevel returns "off" when
+      // the level is unsupported or the user disabled thinking.
+      const requestedLevel = options?.reasoning;
+      const clamped = requestedLevel ? clampThinkingLevel(model, requestedLevel) : undefined;
+      const reasoningLevel = clamped === "off" ? undefined : clamped;
+      const parameters: Record<string, unknown> = { max_tokens: maxTokens };
+      if (reasoningLevel) {
+        parameters.enable_thinking = true;
+        // Effort-based models advertise concrete effort names in the map
+        // (low/medium/xhigh/max). Toggle-only models map every level to
+        // "enabled"/"disabled" and accept no effort value — only the on/off
+        // switch matters, so we send enable_thinking alone.
+        const mapped = model.thinkingLevelMap?.[reasoningLevel];
+        const effort = mapped && mapped !== "enabled" && mapped !== "disabled" ? mapped : reasoningLevel;
+        // Only send reasoning_effort when the upstream model actually exposes
+        // effort levels (thinking_config.enabled.efforts).
+        if (modelConfig?.thinking_config?.enabled?.efforts && typeof effort === "string") {
+          parameters.reasoning_effort = effort;
+        }
+      } else {
+        // No reasoning level selected (or clamped to off): explicitly disable
+        // thinking so the model does not reason by default.
+        parameters.enable_thinking = false;
+      }
+
       const reqBody: Record<string, unknown> = {
         request_id: crypto.randomUUID(),
         request_set_id: recordID,
@@ -197,7 +230,7 @@ export function streamQoder(
         system: "",
         messages: systemText ? [{ role: "system", content: systemText }, ...normalizedMessages] : normalizedMessages,
         tools: toolsRaw || [],
-        parameters: { max_tokens: maxTokens },
+        parameters,
         chat_context: {
           chatPrompt: "",
           imageUrls: null,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -128,7 +128,6 @@ export function streamQoder(
       const modelConfig = getCachedModelConfig(model.id, providerMode) || {
         key: model.id,
         is_reasoning: false,
-        max_output_tokens: 32768,
         source: "system",
       };
       // Use the cached entry's original upstream key when available; fall back to
@@ -136,7 +135,6 @@ export function streamQoder(
       const qoderModel = modelConfig.key || model.id;
 
       const isReasoning = !!modelConfig.is_reasoning;
-      const maxOutputTokens = modelConfig.max_output_tokens || 32768;
 
       const normalizedMessages = transformMessagesForQoder(context.messages);
       const systemText = context.systemPrompt || "";
@@ -163,10 +161,10 @@ export function streamQoder(
         ? `${stablePart}-${options.sessionId}`
         : `${stablePart}-${crypto.randomUUID()}`;
 
+      // Qoder's catalog exposes no per-model output cap (no max_output_tokens),
+      // so we default to 32K (matches qodercli's 32e3 fallback) and let pi cap it
+      // lower when the caller sets options.maxTokens (e.g. compaction at 40K).
       let maxTokens = 32768;
-      if (maxOutputTokens > 0) {
-        maxTokens = maxOutputTokens;
-      }
       if (options?.maxTokens && options.maxTokens < maxTokens) {
         maxTokens = options.maxTokens;
       }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -15,7 +15,6 @@ import {
   buildAuthHeaders,
   getMachineId,
   getQoderChatURL,
-  getQoderCNDirectModel,
   getQoderMode,
   getQoderUserEmailFallback,
   isQoderCNMode,
@@ -120,18 +119,20 @@ export function streamQoder(
       const email = cachedCreds?.email || getQoderUserEmailFallback(providerMode);
       const machineID = cachedCreds?.machineID || getMachineId();
 
-      const qoderModel = isQoderCNMode(providerMode) ? getQoderCNDirectModel(model.id) : model.id;
-      const modelConfig = getCachedModelConfig(qoderModel, providerMode) || {
-        key: qoderModel,
-        is_reasoning:
-          qoderModel === "ultimate" ||
-          qoderModel === "performance" ||
-          qoderModel.includes("dmodel") ||
-          qoderModel.includes("dfmodel"),
+      // The model `id` pi exposes is the upstream display_name (whitespace
+      // stripped) for CN, or the raw key for the international site. The
+      // request-time upstream `key` is read back from the cached model config
+      // (which stores the original entry keyed by both `key` and `id`), so no
+      // key<->friendlyId mapping table is needed here.
+      const modelConfig = getCachedModelConfig(model.id, providerMode) || {
+        key: model.id,
+        is_reasoning: false,
         max_output_tokens: 32768,
         source: "system",
       };
-      modelConfig.key = qoderModel;
+      // Use the cached entry's original upstream key when available; fall back to
+      // the pi id (international site already uses the key as id).
+      const qoderModel = modelConfig.key || model.id;
 
       const isReasoning = !!modelConfig.is_reasoning;
       const maxOutputTokens = modelConfig.max_output_tokens || 32768;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -20,7 +20,7 @@ import {
   getQoderUserEmailFallback,
   isQoderCNMode,
 } from "./cosy.js";
-import { getCachedModelConfig } from "./models.js";
+import { getCachedModelConfig, MAX_OUTPUT_TOKENS } from "./models.js";
 import { getCachedCredentials } from "./oauth.js";
 import { qoderEncodeBody } from "./qoder-encoding.js";
 import { stripThinkingTags, ThinkingTagParser } from "./thinking-parser.js";
@@ -161,10 +161,12 @@ export function streamQoder(
         ? `${stablePart}-${options.sessionId}`
         : `${stablePart}-${crypto.randomUUID()}`;
 
-      // Qoder's catalog exposes no per-model output cap (no max_output_tokens),
-      // so we default to 32K (matches qodercli's 32e3 fallback) and let pi cap it
-      // lower when the caller sets options.maxTokens (e.g. compaction at 40K).
-      let maxTokens = 32768;
+      // Qoder's catalog exposes no per-model output cap, so we use the
+      // documented upstream ceiling (MAX_OUTPUT_TOKENS = 131072, see models.ts)
+      // and let pi cap it lower when the caller sets options.maxTokens (e.g.
+      // compaction at 40K). This avoids truncating reasoning chains / long
+      // generations that the 32K default would cut off.
+      let maxTokens = MAX_OUTPUT_TOKENS;
       if (options?.maxTokens && options.maxTokens < maxTokens) {
         maxTokens = options.maxTokens;
       }


### PR DESCRIPTION
## 背景

Qoder CN 的 provider 之前用硬编码表维护模型映射，且未把推理等级转发给上游，导致：

- 模型 id 映射表随上游改版频繁失配（型号名/版本号对不上）
- picker 显示的推理档位与上游实际支持的不一致（如 qwen3.8-max 的 `xhigh` 被隐藏）
- 用户选的推理等级从未发送，模型始终按默认推理
- `max_tokens` 固定 32K，仅用官方 API 的 1/4，思考模式下会截断思维链

## 改动

**1. 输出上限：32K → 128K**
新增 `MAX_OUTPUT_TOKENS = 131072` 作为唯一来源，静态模型与请求发送统一引用。
依据阿里云百炼官方文档：qwen3.8-max/flash、qwen3.7-max/plus/flash 的 Max Output Length 均为 131072（思考模式同值，思维链单独上限 262144）。32K 会截断思考模式输出。

**2. 推理等级回传**
解包 `@qoder-ai/qodercli` 确认请求体在 `parameters` 内携带 `reasoning_effort` + `enable_thinking`。
- `models.ts`：新增 `buildThinkingLevelMap()` 解析 `thinking_config`，effort 模型按支持档位映射、toggle 模型映射为开关，`off` 在有 `disabled` 选项时可选
- `stream.ts`：`clampThinkingLevel` 将请求等级压到模型支持的档位，映射为上游 effort 名回传；toggle 模型只发 `enable_thinking`；未选/关闭时 `enable_thinking: false`

**3. 上下文：默认 180K → 200K**
弃用 `max_input_tokens`（恒为 180K，被所有可选上下文超过，是冗余下限）。改为从 `context_config` 取最大可选档（如 1M），无 `context_config` 时回退 200K。

**4. 模型显示机制：硬编码表 → 动态**

删除 `qoderCNFriendlyModels` / `getQoderCNDirectModel` / `getQoderCNFriendlyModelInfo` / `prettifyQoderCNModelName` 等映射表。`/model` 列表直接显示上游 `display_name`，发送时用 `model key`。

| picker 显示 (`Model.id`) | 缓存 `key` | 发送时 `model_config.key` |
| --- | --- | --- |
| `Qwen3.8-Max` | `qmodel_38max` | `qmodel_38max` |
| `Qwen3.8-Flash` | `qfmodel` | `qfmodel` |
| `Auto` | `auto` | `auto` |

缓存按 `key` 和 `display_name` 双索引存储，发送时用 `Model.id` 反查回 `key`，无需 id↔key 转换表。型号重命名/升级后自动跟随。

## 验证
- `check` / `lint` / 115 个测试全过
- 真实 CN 端请求验证：`max_tokens=131072` 返回 200/stop（被接受）；xhigh 推理 `finish_reason=stop`（未截断）；`reasoning_effort` 字段确认在 `parameters` 内被接受
