### PR TITLE
perf: optimize Qoder body encoding for large requests

### DIFF
--- a/src/protocol/encoding.ts
+++ b/src/protocol/encoding.ts
@@ -1,24 +1,46 @@
 const qoderCustomAlphabet = "_doRTgHZBKcGVjlvpC,@aFSx#DPuNJme&i*MzLOEn)sUrthbf%Y^w.(kIQyXqWA!";
+
 const qoderStdAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+const encodeTable = new Uint8Array(256);
+
+for (let i = 0; i < encodeTable.length; i++) {
+  encodeTable[i] = i;
+}
+
+for (let i = 0; i < qoderStdAlphabet.length; i++) {
+  encodeTable[qoderStdAlphabet.charCodeAt(i)] = qoderCustomAlphabet.charCodeAt(i);
+}
+
+// Qoder uses "$" instead of standard Base64 "=" padding.
+encodeTable["=".charCodeAt(0)] = "$".charCodeAt(0);
 
 export function qoderEncodeBody(plaintext: string | Buffer): string {
   const std = Buffer.isBuffer(plaintext) ? plaintext.toString("base64") : Buffer.from(plaintext).toString("base64");
-  const n = std.length;
+
+  const src = Buffer.from(std, "ascii");
+  const n = src.length;
   const a = Math.floor(n / 3);
-  const rearranged = std.slice(n - a) + std.slice(a, n - a) + std.slice(0, a);
-  let out = "";
-  for (let i = 0; i < n; i++) {
-    const c = rearranged[i];
-    if (c === "=") {
-      out += "$";
-    } else {
-      const idx = qoderStdAlphabet.indexOf(c);
-      if (idx >= 0) {
-        out += qoderCustomAlphabet[idx];
-      } else {
-        out += c;
-      }
-    }
+
+  const out = Buffer.allocUnsafe(n);
+  let dst = 0;
+
+  // Equivalent to:
+  // std.slice(n - a) + std.slice(a, n - a) + std.slice(0, a)
+  //
+  // Translate directly into the output buffer to avoid building a large
+  // rearranged string and repeatedly concatenating one-character strings.
+  for (let i = n - a; i < n; i++) {
+    out[dst++] = encodeTable[src[i]];
   }
-  return out;
+
+  for (let i = a; i < n - a; i++) {
+    out[dst++] = encodeTable[src[i]];
+  }
+
+  for (let i = 0; i < a; i++) {
+    out[dst++] = encodeTable[src[i]];
+  }
+
+  return out.toString("ascii");
 }


### PR DESCRIPTION
## Summary

Optimize `qoderEncodeBody()` to reduce CPU and GC overhead when encoding large request bodies.

The previous implementation built an intermediate rearranged string and then appended the encoded output one character at a time with `out += ...`.

With large Pi tool-call payloads, this caused significant V8 string flattening and garbage collection overhead.

## Changes

- Precompute a byte translation table for the custom Qoder Base64 alphabet
- Preallocate the final output buffer
- Perform rearrangement directly into the output buffer
- Avoid the intermediate `rearranged` string
- Avoid repeated single-character string concatenation

The encoded wire format remains unchanged.

## Observed issue

In real Pi sessions using Qoder providers, large requests could cause the Node main thread to stay at high CPU usage for a long time.

`perf` showed hotspots around:

- `String::SlowFlatten`
- `String::WriteToFlat`
- `Runtime_StringCharCodeAt`
- `memmove`
- V8 garbage collection

After replacing the string-concatenation path with the buffer-based implementation, the CPU spike no longer reproduced in the same workflow.

## Validation

- Existing encoding tests pass
- Type check passes
- Lint/format checks pass
- Build passes